### PR TITLE
Show page title in <title>

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,6 @@
 <head>
     <meta charset="utf-8">
-    <title>Bytecode Alliance</title>
+    <title>{% if page.title %}{{ page.title }}{% else %}Bytecode Alliance{% endif %}</title>
     <meta content="width=device-width, initial-scale=1" name="viewport">
     <link href="{{ site.baseurl }}/css/normalize.css" rel="stylesheet" type="text/css">
     <link href="{{ site.baseurl }}/css/webflow.css" rel="stylesheet" type="text/css">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,6 @@
 <head>
     <meta charset="utf-8">
-    <title>{% if page.title %}{{ page.title }}{% else %}Bytecode Alliance{% endif %}</title>
+    <title>Bytecode Alliance{% if page.title %} — {{ page.title }}{% endif %}</title>
     <meta content="width=device-width, initial-scale=1" name="viewport">
     <link href="{{ site.baseurl }}/css/normalize.css" rel="stylesheet" type="text/css">
     <link href="{{ site.baseurl }}/css/webflow.css" rel="stylesheet" type="text/css">


### PR DESCRIPTION
Right now the title of every page on the site is the same, including this one:

https://bytecodealliance.org/articles/wasmtime-1-0-fast-safe-and-production-ready