### PR TITLE
Removed EDJX logo (no longer a member)

### DIFF
--- a/index.md
+++ b/index.md
@@ -57,7 +57,6 @@ The Bytecode Alliance welcomes contributions and participation from across the i
 <img src="images/member-logos/cosmonic.png" alt="Cosmonic Logo">
 <img src="images/member-logos/dfinity.png" alt="DFINITY Logo">
 <img src="images/member-logos/docker.png" alt="Docker Logo">
-<img src="images/member-logos/edjx.png" alt="EDJX Logo">
 <img src="images/member-logos/embark-studios.png" alt="Embark Studios Logo">
 <img src="images/member-logos/fastly.svg" alt="Fastly Logo">
 <img src="images/member-logos/fermyon.svg" alt="Fermyon Logo">


### PR DESCRIPTION
EDJX decided not to renew their membership, so I've removed their logo from the list of members on our home page.  (I left the logo file in place in case they changed their mind and wanted to rejoin later on, though perhaps that's a bad idea given the file would still be visible on our website if someone knew where to look...)