### PR TITLE
Replicating site update changes from staging for production

### DIFF
--- a/_data/board.yml
+++ b/_data/board.yml
@@ -1,0 +1,49 @@
+# List of Board Members with title, office, and github ID.
+# Used to generate the gallery of Board members on the site About page,
+# including photos based on GitHub avatars.  Also links to Board
+# members' GitHub profiles for further info.
+- name: Bobby Holley
+  github: bholley
+  title: Member Director (Mozilla)
+  office: Board Chair
+
+- name: Bailey Hayes
+  github: ricochet
+  title: TSC Director
+  office: 
+
+- name: Daniel Lopez Ridruejo
+  github: ridruejo
+  title: Member Director (VMware)
+  office: 
+
+- name: Tyler McMullen
+  github: tyler
+  title: Member Director (Fastly)
+  office: 
+
+- name: Till Schneidereit
+  github: tschneidereit
+  title: At-Large Director
+  office: 
+
+- name: Ralph Squillace
+  github: squillace
+  title: Member Director (Microsoft)
+  office: Treasurer
+
+- name: Deian Stefan
+  github:  deian
+  title: Member Director (UCSD)
+  office: 
+
+- name: Mingqiu Sun
+  github: mingqiusun
+  title: Member Director (Intel)
+  office: 
+
+# List the Executive Director last (here):
+- name: David Bryant
+  github: disquisitioner
+  title: Consulting Executive Director
+  office: 

--- a/_data/tsc.yml
+++ b/_data/tsc.yml
@@ -1,0 +1,18 @@
+# List of TSC members with title, office, and github ID.
+# Used to generate the gallery of TSC members on the site About page,
+# including photos based on GitHub avatars.  Also links to TSC
+# members' GitHub profiles for further info.
+- name: Nick Fitzgerald
+  github: fitzgen
+  title: Elected Delegate
+  office: TSC Chair
+
+- name: Bailey Hayes
+  github: ricochet
+  title: Elected Delegate
+  office: 
+
+- name: Till Schneidereit
+  github: tschneidereit
+  title: Elected Delegate
+  office: 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,7 @@
 
 <footer class="section-footer">
     <div class="container w-container">
-        <div class="right-text"><a href="{{ site.baseurl }}/assets/bylaws.pdf">Bylaws</a> | <a href="{{ site.baseurl }}/assets/ip-policy.pdf">IP Policy</a> | Copyright © 2019-2021 the Bytecode Alliance contributors.</div>
+        <div class="right-text"><a href="{{ site.baseurl }}/assets/bylaws.pdf">Bylaws</a> | <a href="{{ site.baseurl }}/assets/ip-policy.pdf">IP Policy</a> | Copyright © 2019-2023 the Bytecode Alliance contributors.</div>
     </div>
 </footer>
 

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -7,18 +7,10 @@
 
     <div id="nav-entries" class="container w-container">
         <ul role="navigation">
-            <li><a href="{{ site.baseurl }}/security">Security</a></li>
-            <li><a href="{{ site.baseurl }}/mission">Mission &amp; Values</a></li>
-            <li><a href="{{ site.baseurl }}/press">Announcements</a></li>
-            <li><a href="{{ site.baseurl }}/articles">Articles</a></li>
-            <li id="projects-nav">
-                <a>Projects</a>
-                <ul>
-                    <li><a href="https://wasmtime.dev">Wasmtime</a></li>
-                    <li><a href="https://github.com/bytecodealliance/wasmtime/tree/main/cranelift">Cranelift</a></li>
-                    <li><a href="https://github.com/bytecodealliance/wasm-micro-runtime">WAMR</a></li>
-                </ul>
-            </li>
+            <li><a href="{{ site.baseurl }}/">Home</a></li>
+            <li><a href="{{ site.baseurl }}/about">About</a></li>
+            <li><a href="{{ site.baseurl }}/articles">News</a></li>
+            <li><a href="{{ site.baseurl }}/projects">Projects</a></li>
             <li class="join-button"><a href="{{ site.baseurl }}/membership">Membership</a></li>
             <li class="github-link"><a href="https://github.com/bytecodealliance/">
                     <img src="{{ site.baseurl }}/images/github-icon.svg" alt="GitHub link" class="github">

--- a/_posts/2019-11-12-formation.md
+++ b/_posts/2019-11-12-formation.md
@@ -1,0 +1,45 @@
+---
+layout: press_release
+name: "Announcing the Bytecode Alliance"
+date: "2019-11-12"
+title: "New Bytecode Alliance Brings the Security, Ubiquity, and Interoperability of the Web to the World of Pervasive Computing"
+subtitle: "New community effort will create a new cross-platform, cross-device computing runtime based on the unique advantages of WebAssembly"
+author: Bytecode Alliance
+github_name: bytecodealliance
+---
+
+**MOUNTAIN VIEW, California November 12, 2019 --** The Bytecode Alliance is a newly-formed open source community dedicated to creating new software foundations, building on standards such as WebAssembly and WebAssembly System Interface (WASI). Mozilla, Fastly, Intel, and Red Hat are founding members.
+
+The Bytecode Alliance will, through the joint efforts of its contributing members, deliver a state-of-the-art runtime environment and associated language toolchains, where security, efficiency, and modularity can all coexist across the widest possible range of devices and architectures. Technologies contributed and collaboratively evolved through the Alliance leverage established innovation in compilers, runtimes, and tooling, and focus on fine-grained sandboxing, capabilities-based security, modularity, and standards such as WebAssembly and WASI.
+
+Founding members are making several open source project contributions to the Bytecode Alliance, including:
+
+1. [Wasmtime](https://github.com/bytecodealliance/wasmtime), a small and efficient runtime for WebAssembly &amp; WASI
+2. [Lucet](https://github.com/bytecodealliance/lucet), an ahead-of-time compiler and runtime for WebAssembly &amp; WASI focused on low-latency, high-concurrency applications
+3. [WebAssembly Micro Runtime (WAMR)](https://github.com/bytecodealliance/wasm-micro-runtime), an interpreter-based WebAssembly runtime for embedded devices
+4. [Cranelift](https://github.com/bytecodealliance/wasmtime/tree/main/cranelift), a cross-platform code generator with a focus on security and performance, written in Rust
+
+
+Modern software applications and services are built from global repositories of shared components and frameworks, which greatly accelerates creation of new and better multi-device experiences but understandably increases concerns about trust, data integrity, and system vulnerability. The Bytecode Alliance is committed to establishing a capable, secure platform that allows application developers and service providers to confidently run untrusted code, on any infrastructure, for any operating system or device, leveraging decades of experience doing so inside web browsers.
+
+
+<blockquote>
+“WebAssembly is changing the web, but we believe WebAssembly can play an even bigger role in the software ecosystem as it continues to expand beyond browsers. This is a unique moment in time at the dawn of a new technology, where we have the opportunity to fix what’s broken and build new, secure-by-default foundations for native development that are portable and scalable. But we need to take deliberate, cross-industry action to ensure this happens in the right way. Together with our partners in the Bytecode Alliance, Mozilla is building these new secure foundations—for everything from small, embedded devices to large, computing clouds,”
+<cite>— Luke Wagner, Distinguished Engineer at Mozilla, co-creator of WebAssembly</cite>
+</blockquote>
+
+
+<blockquote>
+“Fastly is very happy to help bring the Bytecode Alliance to the community. Lucet and Cranelift have been developed together for years, and we’re excited to formalize their relationship and help them grow faster together. This is an important moment in computing history, marking our chance to redefine how software will be built across clients, origins, and the edge. The Bytecode Alliance is our way of contributing to and working with the community, to create the foundations that the future of the internet will be built on."
+<cite>— Tyler McMullen, CTO at Fastly</cite>
+</blockquote>
+
+<blockquote>
+“Intel is joining the Bytecode Alliance as a founding member to help extend WebAssembly’s performance and security benefits beyond the browser to a wide range of applications and servers. Bytecode Alliance technologies can help developers extend software using a wide selection of languages, building upon the full capabilities of leading-edge compute platforms”
+<cite>— Mark Skarpness; VP, Intel Architecture, Graphics, and Software; Director, Data-Centric System Stacks</cite>
+</blockquote>
+
+<blockquote>
+“Red Hat believes deeply in the role open source technologies play in helping provide the foundation for computing, from the operating system to the browser to the open hybrid cloud. Wasmtime is an exciting development that helps move WebAssembly out of the browser into the server space where we are experimenting with it to change the trust model for applications, and we are happy to be involved in helping it grow into a mature, community-based project.”
+<cite>— Chris Wright, senior vice president and Chief Technology Officer at Red Hat</cite>
+</blockquote>

--- a/_posts/2021-04-28-calling-for-new-members.md
+++ b/_posts/2021-04-28-calling-for-new-members.md
@@ -1,0 +1,37 @@
+---
+layout: press_release
+name: "Bytecode Alliance calling for new members"
+date: "2021-04-28"
+title: "The Bytecode Alliance Calls for New Members In Mission to Build Safer Software Foundations for the Internet"
+subtitle: "The nonprofit focused on building an ecosystem to advance the unique advantages of WebAssembly is seeking new members"
+author: Bytecode Alliance
+github_name: bytecodealliance
+---
+
+**SAN FRANCISCO --- April 28, 2021 ---** The Bytecode Alliance, a community dedicated to creating new software foundations, building on standards such as WebAssembly and WebAssembly System Interface (WASI), today announced incorporation as a 501(c)(6) non-profit organization. Incorporated by [Fastly](https://fastly.com), [Intel](https://www.intel.com/content/www/us/en/homepage.html), [Mozilla](https://www.mozilla.org/en-US/) and [Microsoft](https://www.microsoft.com/en-us/), the Bytecode Alliance now invites organizations to join its cross-industry collaborative mission alongside new members [Arm](https://www.arm.com/), [DFINITY Foundation](https://dfinity.org/), [Embark Studios](https://www.embark-studios.com/), [Google](https://research.google.com/), [Shopify](https://shopify.engineering/), and [University of California at San Diego](https://ucsd.edu/).
+
+These organizations share a vision of a WebAssembly ecosystem that fixes cracks in today’s software foundations that are holding the industry and its software supply chains back from a secure, performant, cross-platform and cross-device future. Bytecode Alliance members believe effective multi-stakeholder collaboration is vital to achieving this vision of software foundations that enable security, efficiency, and modularity to coexist across the widest possible range of devices and architectures.
+
+The Bytecode Alliance, founded in 2019, has helped bring attention to the inherent weaknesses in predominant models for building software, which rely heavily on composing up to thousands of third-party modules without security boundaries between them. These [weaknesses](https://www.dni.gov/files/NCSC/documents/supplychain/Software_Supply_Chain_Attacks.pdf) in the software supply chain have historically [been instrumental](https://en.wikipedia.org/wiki/Supply_chain_attack) in breaching government systems, critical infrastructure services, and a large number of companies, as well as in stealing personal information of hundreds of millions, perhaps even billions of people. Solving these challenges will require efforts across many industries. With an open governance model and a growing list of member organizations, the Bytecode Alliance will scale its efforts to contribute solutions to this space in support of its [mission]({{ site.baseurl }}/mission).
+
+Organizations passionate about contributing to this mission and building new, more secure foundations for the cloud, the edge, the Internet of Things, and many other environments and platforms, are invited to apply to become members. Membership applications will be reviewed on a rolling basis, but those submitted in the near future will have an opportunity to participate in full board elections in the second half of 2021.
+
+<blockquote>
+Collaboration across the industry to build stronger software foundations is crucial to securing the future of a safer and more efficient web. The WebAssembly ecosystem is an exciting, powerful world that will make possible a lot of ‘what ifs’ in building secure applications and software across clients, origins, and the edge. Every bit of progress the Bytecode Alliance makes to standardize these software development practices is another chapter in computing history. Fastly is thrilled to be an incorporating member and to welcome new and future Alliance members who share this vision.
+<cite>-- Tyler McMullen, CTO at Fastly</cite>
+</blockquote>
+
+<blockquote>
+As an incorporating member of the Bytecode Alliance, Intel welcomes the new members and recognizes the importance of a secure and open WebAssembly ecosystem driven by industry collaboration. Intel continues to extend WebAssembly’s performance and security benefits outside of the browser, most recently driving the WebAssembly System Interface for Neural Network specification and implementation in Wasmtime to enable higher machine learning inferencing performance in WebAssembly.
+<cite>-- Mark Skarpness, VP, Intel Architecture, Graphics, and Software; General Manager, System Software Engineering at Intel</cite>
+</blockquote>
+
+<blockquote>
+We have a real opportunity to change how software is built, and in doing so, enable small teams to build big things that are both secure and fast. Mozilla believes that WebAssembly has the right technical ingredients to build a better, more secure Internet, and that the Bytecode Alliance has the vision and momentum to make it happen.
+<cite>-- Bobby Holley, Distinguished Engineer at Mozilla and Bytecode Alliance Board Member</cite>
+</blockquote>
+
+<blockquote>
+Microsoft is excited to join the Bytecode Alliance as an incorporating member to support the effort to build a more open, scalable, secure web. WebAssembly and the emerging WebAssembly System Interface (WASI) specification enable cloud-native solutions to become more secure by default and help solve computing challenges across a variety of environments, including the ‘tiny edge’ of systems-on-a-chip (SoCs) and microcontroller units (MCUs). Microsoft looks forward to collaborating with the Bytecode Alliance members and community as this ecosystem continues to rapidly innovate and grow.
+<cite>-- Ralph Squillace, Principal Program Manager, Azure Core Upstream at Microsoft and Bytecode Alliance Board Member</cite>
+</blockquote>

--- a/_posts/2023-02-21-wasi-threads.md
+++ b/_posts/2023-02-21-wasi-threads.md
@@ -2,6 +2,7 @@
 title: "Announcing wasi-threads"
 author: "Andrew Brown"
 github_name: abrown
+excerpt_separator: <!--end_excerpt-->
 ---
 
 Until now, one piece missing from WebAssembly standalone engines was the ability to spawn threads.
@@ -11,6 +12,7 @@ way to do this. This post describes the work of several collaborators to bring a
 will explain the history to this proposal, the work done to get to this point, and how one can
 experiment with threaded applications in engines like Wasmtime and WAMR. To showcase this, we'll
 look at how performing parallel compression with wasi-threads drastically improves performance.
+<!--end_excerpt-->
 
 ## History
 

--- a/_posts/2023-02-28-community-stream.md
+++ b/_posts/2023-02-28-community-stream.md
@@ -44,3 +44,4 @@ At **6PM PST** today (February 28th) we'll host our next community stream. We wi
 Until next time!
 
 Bailey
+

--- a/_posts/2023-03-28-component-model-tooling-compatibility.md
+++ b/_posts/2023-03-28-component-model-tooling-compatibility.md
@@ -2,6 +2,7 @@
 title: "Component Model Tooling Compatibility"
 author: "Peter Huene"
 github_name: peterhuene
+excerpt_separator: <!--end_excerpt-->
 
 # Published versions
 wasmtime: 7.0.0
@@ -33,6 +34,7 @@ Here at the Bytecode Alliance, we are very excited about the potential of the
 [WebAssembly Component Model][proposal] proposal and we understand that many of 
 you are actively exploring ways to build solutions that use WebAssembly 
 components as well!
+<!--end_excerpt-->
 
 We have been working hard on an implementation of the proposal across many of 
 our repositories. However, keeping track of the various versions of the tooling 

--- a/about.md
+++ b/about.md
@@ -1,0 +1,100 @@
+---
+layout: default
+permalink: /about
+---
+
+<section>
+    <div class="container w-container">
+        <div class="width-container" markdown="1">
+
+## [Mission](#mission)
+Our mission is to Provide state-of-the-art foundations to develop runtime environments and language toolchains where security, efficiency, and modularity can all coexist across a wide range of devices and architectures. We enable innovation in compilers, runtimes, and tooling, focusing on fine-grained sandboxing, capabilities-based security, modularity, and standards such as WebAssembly and WASI.
+</div>
+</div>
+</section>
+
+<section>
+   <div class="container w-container">
+      <div class="width-container">
+         <h2>Board</h2>
+         <p>
+         Our Board is comprised of Directors elected from among our member organizations, the Technical Steering Committee, and our Recognized Contributors program. Board members are selected to a two-year term, staggered across elections every December. 
+         </p>
+         <div id="board-gallery">
+            {% comment %}Generate gallery of Board members from list in _data/board.yml{% endcomment %}
+            {% for member in site.data.board %}
+            <div class="board-member">
+               <img src="https://github.com/{{member.github}}.png">
+               <div>
+                  <h4>{{member.name}}</h4>
+                  {{member.title}}<br>
+                  {% if member.office %}
+                     {{member.office }}<br>
+                  {% endif %}
+                  GitHub: <a href="https://github.com/{{member.github}}">{{member.github}}</a>
+               </div>
+            </div>
+            {% endfor %}
+         </div>
+         <p>
+             The Consulting Executive Director supports the Board and oversees day-to-day operations as well as member relations.
+          </p>
+         <h2>Technical Steering Committee</h2>
+         <p>
+            The Bytecode Alliance <a href="https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md">Technical Steering Committee</a> ("TSC") acts as the top-level governing body for projects and Special Interest Groups hosted by the Alliance, ensuring they further the Alliance's mission and are conducted in accordance with our <a href="#social-values">values and principles</a>.  The TSC also oversees the Bytecode Alliance <a href="https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#recognized-contributors">Recognized Contributor</a> program to encourage and engage individual contributors as participants in Alliance projects and groups.
+         </p>
+         <div id="board-gallery">
+           {% comment %}Generate gallery of TSC members from list in _data/tsc.yml{% endcomment %}
+           {% for member in site.data.tsc %}
+            <div class="board-member">
+               <img src="https://github.com/{{member.github}}.png">
+               <div>
+                  <h4>{{member.name}}</h4>
+                  {{member.title}}<br>
+                  {% if member.office %}
+                     {{member.office }}<br>
+                  {% endif %}
+                  GitHub: <a href="https://github.com/{{member.github}}">{{member.github}}</a>
+               </div>
+            </div>
+            {% endfor %}
+        </div>
+      </div>
+   </div>
+</section>
+
+<section>
+    <div class="container w-container">
+        <div class="width-container" markdown="1">
+
+## [Values](#values)
+
+### [Social Values](#social-values)
+1. Collaboration<br>
+   Our alliance facilitates collaborative development.
+2. Inclusiveness<br>
+   Our alliance fosters welcoming, inclusive, and non-discriminatory environments.
+3. Openness<br>
+   What we develop is Free and Open Source, and available for everyone, not just our members. We accept all contributors who are willing and able to collaborate and adhere to our alliance’s values.
+
+### [Technical Values](#technical-values)
+1. Thoughtful balance<br>
+   We recognize that many technical principles stand in tension with each other. We will make thoughtful, explicit trade-offs when necessary, but strive for creative solutions that allow those values to all coexist. In particular, we hold the technical principles of Security, Efficiency, Modularity, and Portability as key concerns to balance in all designs and their implementations.
+2. Documentation and Testing<br>
+   We consider documentation and tests a core part of maintainable, sustainable development.
+
+### [Process Values](#process-values)
+1. Influence through effort<br>
+   We grant influence and decision-making authority through ongoing efforts towards our alliance’s vision and goals, not through monetary contributions.
+2. Sustainable velocity<br>
+   In all design and implementation decisions, we will take care to balance short-term velocity with stability and maintainability, to sustain a healthy velocity in the long term.
+3. Localized governance wherever possible<br>
+   We localize decision-making processes into individual projects where possible. We lift decisions to a higher governance level only when necessary, such as to mediate deadlocks or facilitate cross-project design and implementation decisions.
+4. Disagree and commit<br>
+   We may re-examine decisions given new evidence or new ideas, and we may document disagreement and trade-offs, but we will not undermine each other’s work.
+5. Lightweight processes<br>
+   We introduce processes as-needed, and make them as lightweight as possible.
+
+</div>
+</div>
+</section>

--- a/css/style.css
+++ b/css/style.css
@@ -140,10 +140,36 @@ body[id^="press"] nav a[href^="/press"],
 body[id^="projects"] nav a[href^="/projects"],
 body[id^="articles"] nav a[href^="/articles"],
 body[id^="security"] nav a[href^="/security"],
+body[id^="about"] nav a[href^="/about"],
 body[id^="posts-"] nav a[href^="/articles"] {
   border-bottom: 2px solid #373753;
   color: #373753;
 }
+
+#board-gallery {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  font-size: 0.8em;
+  margin: 1.5em 0 1.5em 1.5em;
+}
+#board-gallery img {
+  width: 125px;
+  height: 125px;
+}
+.board-member {
+  display: flex;
+  flex: 1 400px;
+  gap: 10px;
+  line-height: 1.5em;
+  background: #ffffff;
+  padding: 0px 10px 5px 0px
+}
+.board-member h4 {
+  margin-top: 0.5em;
+  text-align: left;
+}
+
 
 #membership nav a[href="/membership"] {
   background: #387E89;
@@ -196,7 +222,7 @@ body[id^="posts-"] nav a[href^="/articles"] {
   display: none;
 }
 
-#site-nav .github:hover .zulip:hover {
+#site-nav .github:hover .zulip:hover{
   filter: brightness(80%);
 }
 
@@ -232,7 +258,7 @@ body[id^="posts-"] nav a[href^="/articles"] {
   padding: 8px 10px;
 }
 
-@media (max-width: 1175px) {
+@media (max-width: 1100px) {
   #site-nav #menu-button {
     display: block;
   }
@@ -255,26 +281,28 @@ body[id^="posts-"] nav a[href^="/articles"] {
   }
 
   #site-nav ul li,
-  #site-nav ul li.github-link  {
+  #site-nav ul li.github-link {
     position: relative;
     float: none;
-    padding: 10px 0 10px 0px;
+    padding: 10px 0 10px 34px;
     border-bottom: 1px solid #f2f2f2;
   }
   #site-nav ul li.github-link {
     left: -24px;
     top: 0;
   }
-  #site-nav ul li.zulip-link  {
+  #site-nav ul li.zulip-link {
     position: relative;
     float: none;
-    padding: 10px 0 10px 0px;
+    padding: 10px 0 10px 34px;
     border-bottom: 1px solid #f2f2f2;
   }
   #site-nav ul li.zulip-link {
     left: -24px;
     top: 0;
   }
+
+
   #site-nav ul li a {
     margin: 0;
     padding: 0;
@@ -418,7 +446,7 @@ section.news__hero {
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  min-height: 65vh;
+  min-height: 45vh;
   padding-top: 67px;
   -webkit-box-pack: center;
   -webkit-justify-content: center;

--- a/index.md
+++ b/index.md
@@ -9,10 +9,7 @@ layout: default
 <section>
     <div class="container w-container">
         <div class="width-container" markdown="1">
-
-## About the Bytecode Alliance
-
-The Bytecode Alliance is a nonprofit organization dedicated to creating secure new software foundations, building on standards such as [WebAssembly](https://webassembly.org/) and [WebAssembly System Interface (WASI)](https://wasi.dev).
+The **Bytecode Alliance** is a nonprofit organization dedicated to creating secure new software foundations, building on standards such as [WebAssembly](https://webassembly.org/) and [WebAssembly System Interface (WASI)](https://wasi.dev).
 
 The Bytecode Alliance is committed to establishing a capable, secure platform that allows application developers and service providers to confidently run untrusted code, on any infrastructure, for any operating system or device, leveraging decades of experience doing so inside web browsers.
 
@@ -52,7 +49,6 @@ The Bytecode Alliance welcomes contributions and participation from across the i
 <img src="images/member-logos/amazon.png" alt="Amazon Logo">
 <img src="images/member-logos/anaconda.png" alt="Anaconda Logo">
 <img src="images/member-logos/arm.svg" alt="Arm Logo">
-<img src="images/member-logos/asmnext.svg" alt="AsmNext Logo">
 <img src="images/member-logos/candle.png" alt="Candle Logo">
 <img src="images/member-logos/cisco.svg" alt="Cisco Logo">
 <img src="images/member-logos/cosmonic.png" alt="Cosmonic Logo">
@@ -112,7 +108,7 @@ The Bytecode Alliance welcomes contributions and participation from across the i
                 </div>
             </li>
             <li class="fentry" id="why-is-this-important-now">
-                <a href="#why-is-this-important-now"><h3>Why is this an important focus right now?</h3></a>
+                <a href="#why-is-this-important-now"><h3>Why is this an important area for innovation and collaboration?</h3></a>
                 <input type="checkbox">
                 <div class="ficon">
                     <div class="fline fvertical"></div>
@@ -122,13 +118,11 @@ The Bytecode Alliance welcomes contributions and participation from across the i
                 <div class="fanswer">
                 <p>Developers are running untrusted code in many new places, from the cloud to IoT devices. But
                     this opens up many security concerns, and also portability challenges when you try to run
-                    the same code across these different systems. We don’t yet have a solid foundation to build
-                    upon.
+                    the same code across these different systems. We don’t yet have a solid, secure foundation to build upon.
                 </p>
                 <p>
                     With WebAssembly and emerging related standards such as WASI, WebAssembly Interface
-                    Types, and Module Linking, this solid foundation is taking shape. By building this foundation,
-                    we can address some persistent fundamental issues of today’s software development practices.
+                    Types, and Module Linking, this solid foundation is taking shape and beginning to transform computing through growing production deployment. By building and evolving this foundation we can address some persistent fundamental issues of today’s software development practices.
                 </p>
                 </div>
             </li>
@@ -143,7 +137,7 @@ The Bytecode Alliance welcomes contributions and participation from across the i
                 <div class="fanswer">
                 <p>The problem we are attempting to solve is fundamentally a cross-industry problem. We want to
                     allow for safe interaction and code reuse across server, edge, browser, mobile, and more
-                    platforms. These different platforms are developed by different groups across the industry.
+                    platforms. These different operating environments are developed by different groups across the industry.
                     Our intent is to bring them together to solve problems for everyone.</p>
                 </div>
             </li>
@@ -175,32 +169,10 @@ The Bytecode Alliance welcomes contributions and participation from across the i
                     <img src="images/circle.svg" alt="" class="fcircle">
                 </div>
                 <div class="fanswer">
-                <h4>Wasmtime</h4>
-                <p>
-                    <a href="https://github.com/bytecodealliance/wasmtime">Wasmtime</a> is a WebAssembly runtime. It runs WebAssembly outside of the browser, in a fast,
-                    portable, secure, and scalable way.
-                </p>
-                <p>
-                    Wasmtime serves as the base layer for other hosts. For example, Fastly is refactoring the
-                    Lucet runtime on top of Wasmtime, and Red Hat is building a WebAssembly runtime based on
-                    Wasmtime for the Enarx project (part of the Confidential Computing Consortium).
-                </p>
-                <h4>Cranelift</h4>
-                <p>
-                    <a href="https://github.com/bytecodealliance/wasmtime/tree/main/cranelift">Cranelift</a> is a highly optimized code generator, focused on fast compilation. It’s used in
-                    Wasmtime for both JIT and AOT compilation, and is currently being integrated into Firefox as
-                    the optimizing compiler for WebAssembly. It’s also used as an experimental backend for the
-                    Rust compiler.
-                </p>
-                <h4>WebAssembly Micro-Runtime (WAMR)</h4>
-                <p>
-                    <a href="https://github.com/bytecodealliance/wasm-micro-runtime">WAMR</a> is an interpreter based WebAssembly runtime, optimized for embedded and
-                    resource-constrained devices.
-                </p>
-                <h4>Enarx (affiliated)</h4>
-                <p>
-                    <a href="https://enarx.io">Enarx</a> is an application deployment system enabling applications to run within Trusted Execution Environments (TEEs) in a platform independent way. It's a project of the <a href="https://confidentialcomputing.io/">Confidential Computing Consortium</a> that is based on Wasmtime and closely affiliated with the Bytecode Alliance.
-                </p>
+                    <p>Hosted projects and groups are key ways in which the Bytecode Alliance pursues its mission.  While contributions to WebAssembly are happening across a broad and rapidly growing range of community, organizational, and individual efforts, certain projects are recognized by the Bytecode Alliance as central to the vision for WebAssesmbly it shares with its members.  Those projects receive special support through the Bytecode Alliance Board and its Technical Steering Committee, and today include <a href="https://wasmtime.dev/">Wasmtime</a>, <a href="https://github.com/bytecodealliance/wasmtime/tree/main/cranelift">Cranelift</a>, and <a href="https://github.com/bytecodealliance/wasm-micro-runtime">WAMR</a>.  
+                    </p>
+                    <p>You'll find more details about our hosted projects and Bytecode Alliance projects in general on our <a href="{{ site.baseurl }}/projects">Projects</a> page.
+                    </p>
                 </div>
             </li>
             <li class="fentry" id="project-licenses">
@@ -212,7 +184,7 @@ The Bytecode Alliance welcomes contributions and participation from across the i
                     <img src="images/circle.svg" alt="" class="fcircle">
                 </div>
                 <div class="fanswer">
-                <p>The main projects are licensed under the Apache 2.0 license + LLVM exception (which ensures GPL compatibility). Some supporting projects are licensed under Apache 2.0/MIT dual license.</p>
+                <p>Our adopted projects are licensed under the Apache 2.0 license + LLVM exception (which ensures GPL compatibility). Some supporting projects are licensed under Apache 2.0/MIT dual license.</p>
                 </div>
             </li>
             <li class="fentry" id="how-to-get-involved">
@@ -226,17 +198,14 @@ The Bytecode Alliance welcomes contributions and participation from across the i
                 <div class="fanswer">
                 <p>Developers are encouraged to participate in any open source project in the Bytecode Alliance.
                     Each project is governed by its own committer group. Developers who are very active in
-                    shaping a project are eligible for nomination to the project’s committer group.
+                    shaping a project are eligible for nomination to the project’s committer group. Our community <a href="https://www.youtube.com/@bytecodealliance/featured">YouTube channel</a> is an excellent resource for learning more about our projects and how to get involved, including by joining live-streamed regular community meetups.
                 </p>
                 <p>
                     Developers can also join in by integrating the Bytecode Alliance’s projects into their
                     projects and products, and providing feedback based on their use cases.
                 </p>
                 <p>
-                    We're also working on introducing a Technical Steering Committee (TSC) as the top-level body of governance for projects, which is open for participation by all project contributors, and will also choose members for the Bytecode Alliance's highest governance body, the Board of Directors.
-                </p>
-                <p>
-                    Individuals are invited to engage in Bytecode Alliance projects during the current bootstrapping period to participate in elections to the TSC. We'll publish details on the timing for the bootstrapping process as well as eligibility requirements for TSC participation soon.
+                    Our Technical Steering Committee (TSC) is the top-level body of governance for Bytecode Alliance projects and is open for participation by all project contributors. It also manages our Recognized Contributor program, and represents projects and contributors on the Bytecode Alliance's highest governance body, the Board of Directors. More information on the TSC, its responsibilities, and its programs are provided in its <a href="https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md">charter</a>.
                 </p>
                 </div>
             </li>
@@ -249,13 +218,8 @@ The Bytecode Alliance welcomes contributions and participation from across the i
                     <img src="images/circle.svg" alt="" class="fcircle">
                 </div>
                 <div class="fanswer">
-                <p>Organizations can <a href="{{ site.baseurl }}/membership">join the Bytecode Alliance</a> as members, and are encouraged to participate in the Alliance’s open source projects, and to use them in their own projects and products.
-                </p>
                 <p>
-                    We're currently working on bootstrapping full governance for the Bytecode Alliance, at the end
-                    of which we'll instate a Technical Steering Committee (TSC) as the top-level body of project governance,
-                    and hold elections to both the TSC and to the Board of Directors. Organizations are invited to join
-                    during the bootstrapping period to take part in the Board elections. We'll publish details on the timing for the bootstrapping process soon.
+                    Organizations can <a href="{{ site.baseurl }}/membership">join the Bytecode Alliance</a> as members and are encouraged to participate in the Alliance’s open source projects as well as incorporate them into their own projects and products.
                 </p>
                 </div>
             </li>
@@ -268,7 +232,9 @@ The Bytecode Alliance welcomes contributions and participation from across the i
                     <img src="images/circle.svg" alt="" class="fcircle">
                 </div>
                 <div class="fanswer">
-                <p>The Bytecode Alliance follows an open governance model with a Board of Directors as the top-level body of governance, with seats elected by member organizations, and a Technical Steering Committee (TSC), elected from established project contributors. Our <a href="{{ site.baseurl }}/assets/bylaws.pdf">bylaws</a> define the details of top-level governance, and a detailed charter and procedures for the TSC will be developed as part of a bootstrapping period. We'll publish details on the timing for this process soon.</p>
+                <p>
+                    The Bytecode Alliance follows an open governance model through a Board of Directors as the top-level oversight body, with seats elected by member organizations, and through its Technical Steering Committee (TSC), selected from established project contributors. Our <a href="{{ site.baseurl }}/assets/bylaws.pdf">bylaws</a> define the details of top-level governance, with additional details of TSC operations specified in its <a href="https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md">charter</a>.
+                </p>
                 </div>
             </li>
             </ul>

--- a/projects.md
+++ b/projects.md
@@ -1,0 +1,38 @@
+---
+layout: default
+permalink: /projects
+title: Projects
+---
+
+<section>
+    <div class="container w-container">
+        <div class="width-container" markdown="1">
+
+## Bytecode Alliance Projects
+
+An essential way the Bytecode Alliance pursues its mission is to identify and support projects that align with its vision for the evolution of WebAssembly.  Hosting such projects allows the Alliance to contribute greater attention and technical oversight both directly and through collaborative participation from its member organizations.  Requirements for and recognition of adopted projects are managed by the Alliance's Technical Steering Committee per its [charter](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md), and approved by the Board.
+
+## Our Current Projects
+
+<h4>Wasmtime</h4>
+[Wasmtime](https://wasmtime.dev) is a fast, secure and standards compliant runtime for WebAssembly, configurable to support a wide range of deployment environments and which provides a rich set of APIs for interacting with that host environment through the WASI standard.  Wasmtime serves as the base layer for other hosts.
+<h4>Cranelift</h4>
+[Cranelift](https://github.com/bytecodealliance/wasmtime/tree/main/cranelift) is a production-ready low-level retargetable code generator, usable as a back-end for both WebAssembly and non-WebAssembly deployments.  It’s incorporated in Wasmtime for both JIT and AOT compilation, and is also used as an experimental backend for the Rust compiler. 
+<h4>WAMR</h4>
+The WebAssembly Micro Runtime ([WAMR](https://github.com/bytecodealliance/wasm-micro-runtime)) is a lightweight, standalone, interpreter-based WebAssembly runtime with small footprint, high performance and highly configurable features. It is especially well suited for embedded or similarly resource constrained environments (e.g., Internet of Things).
+
+</div>
+</div>
+</section>
+
+<section>
+    <div class="container w-container">
+        <div class="width-container" markdown="1">
+
+## Project Security
+
+The Bytecode Alliance maintains an active security management and monitoring posture across all of its projects.  If you think you have found a security issue in a Bytecode Alliance project or would like to know more, please consult our [Security Policy]({{ site.baseurl }}/security) for details on reporting, disclosure, and remediation.
+
+</div>
+</div>
+</section>


### PR DESCRIPTION
This branch and pull request integrates for deployment the format, navigation, and content changes associated with a significant revision to the overall site:

- Converges posts (articles) and press (announcements) into a single "News" category. Converts the two prior announcements into posts so everything is in one series of news items.
- Introduces an "About" page for info on the Board, TSC, governance, etc., including a photo gallery for Board and TSC members.
- Converts the Projects menu into a Projects page, with a bit of context on each Hosted Project with links from there to those projects' primary sites
- Preserves the Security page at /security but makes it part of the larger Projects context via mention on the Projects page
- Moves "Mission and Values" to the About page
- Revises and simplifies the site main menu to reflect the above changes
- Updates the FAQ, including aligning project descriptions and links with the new Projects page

The overall style is unchanged, as is the process for adding new articles (posts), which is currently getting increasing use by our projects and through the efforts of the TSC.   None of these changes altered the responsive behavior of the site in rendering on different sizes and types of devices.

All changes were tested previously on our staging site.  Updates made here were manually replicated and then tested both by live, in-browser comparison to the staging site (running this branch locally via Jekyll) and by clicking on links in each page to confirm they resolve properly.