### PR TITLE
Member logos on the home page are now also links

### DIFF
--- a/_data/members.yml
+++ b/_data/members.yml
@@ -1,0 +1,161 @@
+# List of Bytecode Alliance member organizations with logos and home page.
+# Logos are presumed to reside in the images/member-logos folder and be an
+# image file name present there (prefere transparent PNG or SVG).  Active
+# flag can be used to easily enable/disable member display without removing
+# files or lines of HTML.
+#
+# Used to generate the gallery of member logos on the Alliance home page
+- name: Amazon
+  logo: amazon.png
+  homepage: https://aws.amazon.com
+  active: true
+
+- name: Anaconda
+  logo: anaconda.png
+  homepage: https://anaconda.com
+  active: true
+
+- name: Arm
+  logo: arm.svg
+  homepage: https://arm.com
+  active: true
+
+- name: Candle
+  logo: candle.png
+  homepage: https://candle.dev
+  active: true
+
+- name: Cisco
+  logo: cisco.svg
+  homepage: https://cisco.com
+  active: true
+
+- name: Cosmonic
+  logo: cosmonic.png
+  homepage: https://cosmonic.com
+  active: true
+
+- name: DFINITY
+  logo: dfinity.png
+  homepage: https://dfinity.org
+  active: true
+
+- name: Docker
+  logo: docker.png
+  homepage: https://docker.com
+  active: true
+
+- name: Embark Studios
+  logo: embark-studios.png
+  homepage: https://embark-studios.com
+  active: true
+
+- name: Fastly
+  logo: fastly.svg
+  homepage: https://www.fastly.com
+  active: true
+
+- name: Fermyon
+  logo: fermyon.svg
+  homepage: https://www.fermyon.com
+  active: true
+
+- name: Futurewei
+  logo: futurewei.png
+  homepage: https://www.futurewei.com
+  active: true
+
+- name: Infinyon
+  logo: infinyon.svg
+  homepage: https://infinyon.com
+  active: true
+
+- name: Igalia
+  logo: igalia.png
+  homepage: https://www.igalia.com
+  active: true
+
+- name: Intel
+  logo: intel.svg
+  homepage: https://www.intel.com
+  active: true
+
+- name: Liquid Reply
+  logo: liquidreply.png
+  homepage: https://www.reply.com
+  active: true
+
+- name: Microsoft
+  logo: microsoft.svg
+  homepage: https://www.microsoft.com
+  active: true
+
+- name: Midokura
+  logo: midokura.png
+  homepage: https://www.midokura.com
+  active: true
+
+- name: Mozilla
+  logo: mozilla.svg
+  homepage: https://www.mozilla.org
+  active: true
+
+- name: Nornor
+  logo: nor2.svg
+  homepage: https://nor2.io
+  active: true
+
+- name: Rackner
+  logo: rackner.svg
+  homepage: https://www.rackner.com
+  active: true
+
+- name: Shopify
+  logo: shopify.svg
+  homepage: https://www.shopify.com
+  active: true
+
+- name: Siemens
+  logo: siemens.svg
+  homepage: https://www.siemens.com
+  active: true
+
+- name: SingleStore
+  logo: singlestore.svg
+  homepage: https://www.singlestore.com
+  active: true
+
+- name: StackBlitz
+  logo: stackblitz.svg
+  homepage: https://stackblitz.com
+  active: true
+
+- name: Suborbital
+  logo: suborbital.svg
+  homepage: https://suborbital.dev
+  active: true
+
+- name: Tangram
+  logo: tangram.svg
+  homepage: https://www.tangram.dev
+  active: false
+
+- name: UCSD
+  logo: ucsd.svg
+  homepage: https://ucsd.edu
+  active: true
+
+- name: University of Luxembourg
+  logo: university_luxembourg_snt.png
+  homepage: https://wwwen.uni.lu/snt
+  active: true
+
+- name: VMware
+  logo: vmware.svg
+  homepage: https://www.vmware.com
+  active: true
+
+- name: Shanghai Wudun
+  logo: wudun.png
+  homepage: https://wudun.net
+  active: true

--- a/index.md
+++ b/index.md
@@ -46,37 +46,14 @@ The Bytecode Alliance welcomes contributions and participation from across the i
 ## Members
 
 <div class="member-logos">
-<img src="images/member-logos/amazon.png" alt="Amazon Logo">
-<img src="images/member-logos/anaconda.png" alt="Anaconda Logo">
-<img src="images/member-logos/arm.svg" alt="Arm Logo">
-<img src="images/member-logos/candle.png" alt="Candle Logo">
-<img src="images/member-logos/cisco.svg" alt="Cisco Logo">
-<img src="images/member-logos/cosmonic.png" alt="Cosmonic Logo">
-<img src="images/member-logos/dfinity.png" alt="DFINITY Logo">
-<img src="images/member-logos/docker.png" alt="Docker Logo">
-<img src="images/member-logos/embark-studios.png" alt="Embark Studios Logo">
-<img src="images/member-logos/fastly.svg" alt="Fastly Logo">
-<img src="images/member-logos/fermyon.svg" alt="Fermyon Logo">
-<img src="images/member-logos/futurewei.png" alt="Futurewei Logo">
-<img src="images/member-logos/infinyon.svg" alt="Infinyon Logo">
-<img src="images/member-logos/igalia.png" alt="Igalia Logo">
-<img src="images/member-logos/intel.svg" alt="Intel Logo">
-<img src="images/member-logos/liquidreply.png" alt="Liquid Reply Logo">
-<img src="images/member-logos/microsoft.svg" alt="Microsoft Logo">
-<img src="images/member-logos/midokura.png" alt="Midokura Logo">
-<img src="images/member-logos/mozilla.svg" alt="Mozilla Logo">
-<img src="images/member-logos/nor2.svg" alt="Nornor Logo">
-<img src="images/member-logos/rackner.svg" alt="Rackner Logo">
-<img src="images/member-logos/shopify.svg" alt="Shopify Logo">
-<img src="images/member-logos/siemens.svg" alt="Siemens Logo">
-<img src="images/member-logos/singlestore.svg" alt="Singlestore Logo">
-<img src="images/member-logos/stackblitz.svg" alt="Stackblitz Logo">
-<img src="images/member-logos/suborbital.svg" alt="Suborbital Logo">
-<img src="images/member-logos/tangram.svg" alt="Tangram Logo">
-<img src="images/member-logos/ucsd.svg" alt="UCSD Logo">
-<img src="images/member-logos/university_luxembourg_snt.png" alt="Univ. of Luxembourg Logo">
-<img src="images/member-logos/vmware.svg" alt="VMware Logo">
-<img src="images/member-logos/wudun.png" alt="Wudun Logo">
+    {% comment %}Generate gallery of Member organizations from list in _data/members.yml{% endcomment %}
+    {% for member in site.data.members %}
+        {% if member.active %}
+            <a href="{{member.homepage}}" rel="nofollow">
+                <img src="images/member-logos/{{member.logo}}" alt="{{member.name}} Logo">
+            </a>
+        {% endif %}
+    {% endfor %}
 </div>
 
 </div>
@@ -169,7 +146,7 @@ The Bytecode Alliance welcomes contributions and participation from across the i
                     <img src="images/circle.svg" alt="" class="fcircle">
                 </div>
                 <div class="fanswer">
-                    <p>Hosted projects and groups are key ways in which the Bytecode Alliance pursues its mission.  While contributions to WebAssembly are happening across a broad and rapidly growing range of community, organizational, and individual efforts, certain projects are recognized by the Bytecode Alliance as central to the vision for WebAssesmbly it shares with its members.  Those projects receive special support through the Bytecode Alliance Board and its Technical Steering Committee, and today include <a href="https://wasmtime.dev/">Wasmtime</a>, <a href="https://github.com/bytecodealliance/wasmtime/tree/main/cranelift">Cranelift</a>, and <a href="https://github.com/bytecodealliance/wasm-micro-runtime">WAMR</a>.  
+                    <p>Hosted projects and groups are key ways in which the Bytecode Alliance pursues its mission.  While contributions to WebAssembly are happening across a broad and rapidly growing range of community, organizational, and individual efforts, certain projects are recognized by the Bytecode Alliance as central to the vision for WebAssesmbly it shares with its members.  Those projects receive special support through the Bytecode Alliance Board and its Technical Steering Committee, and today include <a href="https://wasmtime.dev/">Wasmtime</a>, <a href="https://cranelift.dev">Cranelift</a>, and <a href="https://github.com/bytecodealliance/wasm-micro-runtime">WAMR</a>.  
                     </p>
                     <p>You'll find more details about our hosted projects and Bytecode Alliance projects in general on our <a href="{{ site.baseurl }}/projects">Projects</a> page.
                     </p>

--- a/projects.md
+++ b/projects.md
@@ -17,7 +17,7 @@ An essential way the Bytecode Alliance pursues its mission is to identify and su
 <h4>Wasmtime</h4>
 [Wasmtime](https://wasmtime.dev) is a fast, secure and standards compliant runtime for WebAssembly, configurable to support a wide range of deployment environments and which provides a rich set of APIs for interacting with that host environment through the WASI standard.  Wasmtime serves as the base layer for other hosts.
 <h4>Cranelift</h4>
-[Cranelift](https://github.com/bytecodealliance/wasmtime/tree/main/cranelift) is a production-ready low-level retargetable code generator, usable as a back-end for both WebAssembly and non-WebAssembly deployments.  It’s incorporated in Wasmtime for both JIT and AOT compilation, and is also used as an experimental backend for the Rust compiler. 
+[Cranelift](https://cranelift.dev) is a production-ready low-level retargetable code generator, usable as a back-end for both WebAssembly and non-WebAssembly deployments.  It’s incorporated in Wasmtime for both JIT and AOT compilation, and is also used as an experimental backend for the Rust compiler. 
 <h4>WAMR</h4>
 The WebAssembly Micro Runtime ([WAMR](https://github.com/bytecodealliance/wasm-micro-runtime)) is a lightweight, standalone, interpreter-based WebAssembly runtime with small footprint, high performance and highly configurable features. It is especially well suited for embedded or similarly resource constrained environments (e.g., Internet of Things).
 


### PR DESCRIPTION
Issue [#26](https://github.com/bytecodealliance/bytecodealliance.org/issues/26) suggests making member logos on our home page links for each member organization.  That could be easily done in the current home page structure, but would involve a fair amount of copy/paste/modify to convert each explicit logo <img> instance into a HTML anchor.  Rather than do all that repetitive work, I took the liberty of converting that portion of the home page into a Liquid template that generates each member logo as an anchor by looping through contents of a (new) members data YAML file (contained in the _data directory).

As part of that process I included an "active" attribute for each member that controls whether their logo & link appears.  The idea is to make it easy to add new members or deactivate existing ones just by editing the _data/members.yml file (and adding new members' logo images to the same directory we've been using).   Member logos/links will appear in the order reflected in _data/members.yml.

I've tested this change running locally on my development machine, including that all the links work and the icons appear correctly as they do on the public site today.

While I was at it I modified our two references to the Cranelift project (on the home page in the FAQ and on the Projects page) to point to the new cranelift.dev project home page instead of the project's GitHub repo, and I deactivated Tangram as a member given they recently let us know they needed to pause their membership.