### PR TITLE
Add /.well-known/warg/registry.json

### DIFF
--- a/warg-registry.json
+++ b/warg-registry.json
@@ -1,0 +1,8 @@
+---
+layout: none
+permalink: .well-known/warg/registry.json
+---
+{
+        "ociRegistry": "ghcr.io",
+        "ociNamespacePrefix": "bytecodealliance/warg/"
+}


### PR DESCRIPTION
This directs the warg-loader client to use ghcr.io as the bytecodealliace.org warg OCI host.