### PR TITLE
Announcing jco 1.0

### DIFF
--- a/_posts/2024-02-19-jco-1.0.md
+++ b/_posts/2024-02-19-jco-1.0.md
@@ -1,7 +1,7 @@
 ---
 title: "Announcing Jco 1.0"
 author: "Yosh Wuyts"
-date: "2024-02-21"
+date: "2024-02-22"
 github_name: "yoshuawuyts"
 excerpt_separator: <!--end_excerpt-->
 ---
@@ -39,19 +39,22 @@ help people navigate this, here is a quick overview of the three projects and
 what their purpose is at the time of writing:
 
 - [Javy](https://github.com/bytecodealliance/javy): A JavaScript → WASI
-toolchain built for WASI 0.1. This work predates Wasm Components, but Component
-support may be added in the future.
+compiler toolchain built for WASI 0.1 using the [QuickJS JavaScript
+engine](https://bellard.org/quickjs/). This work predates Wasm Components, but
+Component support may be added in the future.
 - [ComponentizeJS](https://github.com/bytecodealliance/ComponentizeJS): A
-JavaScript → WASI toolchain built for WASI 0.2 and Wasm Components. This project
-is newer and not yet considered stable.
+JavaScript → WASI compiler toolchain built for WASI 0.2 and Wasm Components.
+This project is newer and not yet considered stable.
 - [Jco](https://github.com/bytecodealliance/jco): A comprehensive WASI compiler
 toolchain and runtime for JavaScript. This includes a WASI → JS toolchain built
-for WASI 0.2 and Wasm Components.
+for WASI 0.2 and Wasm Components using the [SpiderMonkey JavaScript
+engine](https://spidermonkey.dev).
 
-The goal is for Jco to eventually evolve into a comprehensive toolchain for all
-WASI support and JavaScript Component needs. The command `jco componentize` uses
-ComponentizeJS under the covers, so as jco matures you shouldn't have to think
-about ComponentizeJS much, if at all.
+The goal is for Jco to grow into a comprehensive toolchain which takes care of
+all JavaScript and WebAssembly interactions. Jco already experimentally exposes
+the functionality of ComponentizeJS via the `jco componentize` command. And in
+the future we expect to add support for the [WebAssembly
+registry](https://github.com/bytecodealliance/registry/tree/main) too.
 
 ## Example
 

--- a/_posts/2024-02-19-jco-1.0.md
+++ b/_posts/2024-02-19-jco-1.0.md
@@ -1,7 +1,7 @@
 ---
 title: "Announcing Jco 1.0"
 author: "Yosh Wuyts"
-date: "2024-02-19"
+date: "2024-02-21"
 github_name: "yoshuawuyts"
 excerpt_separator: <!--end_excerpt-->
 ---

--- a/_posts/2024-02-19-jco-1.0.md
+++ b/_posts/2024-02-19-jco-1.0.md
@@ -251,7 +251,7 @@ easily been using JavaScript and Go. Or Rust and Python. The point of the Wasm
 Components and WASI is that we can connect any number of languages to each other
 via a strongly typed ABI.
 
-In this example we've kept things pretty simple: one method which takes strings
+We've intentionally kept things fairly simple: one method which takes strings
 in, and returns strings out. However the [latest version of
 WASI](https://bytecodealliance.org/articles/WASI-0.2) (0.2) provides among other
 things access to asynchronous sockets, timers, and http. Using the same broad

--- a/_posts/2024-02-19-jco-1.0.md
+++ b/_posts/2024-02-19-jco-1.0.md
@@ -45,12 +45,12 @@ compiler toolchain built using the [QuickJS JavaScript
 engine](https://bellard.org/quickjs/). This work predates Wasm Components, but
 support may be added in the future.
 - [ComponentizeJS](https://github.com/bytecodealliance/ComponentizeJS): A
-JavaScript → Wasm Component compiler toolchain with full support for WASI 0.2.
-This project is newer and not yet considered stable.
+JavaScript → Wasm Component toolchain with full support for WASI 0.2 built
+using the [SpiderMonkey JavaScript engine](https://spidermonkey.dev). This
+project is newer and not yet considered stable.
 - [Jco](https://github.com/bytecodealliance/jco): A comprehensive WebAssembly
-Component toolchain and runtime for JavaScript. This includes a Wasm Component → JS
-toolchain with full support for WASI 0.2 built using the [SpiderMonkey
-JavaScript engine](https://spidermonkey.dev).
+Component toolchain and runtime for JavaScript. This includes a Wasm Component →
+JS toolchain with full support for WASI 0.2.
 
 ## Example
 

--- a/_posts/2024-02-19-jco-1.0.md
+++ b/_posts/2024-02-19-jco-1.0.md
@@ -15,6 +15,8 @@ Node.js runtime. And by implementing [WASI
 access the network, filesystem, and other system APIs available in the Node.js
 runtime.
 
+<!--end_excerpt-->
+
 Our goal is for jco to be a comprehensive tool for all Wasm-related operations
 for JavaScript. With Jco 1.0 we're stabilizing the Node.js Wasm Component
 runtime, as well as the toolchain to take Wasm Components written in other

--- a/_posts/2024-02-19-jco-1.0.md
+++ b/_posts/2024-02-19-jco-1.0.md
@@ -253,8 +253,8 @@ project.
 
 We're happy to report that several projects in the wild are already succesfully
 using Jco to build their projects with. One particularly impressive project 
-is by the inimitable [Whitequark](https://github.com/whitequark), who has
-[ported the YoWASP FPGA toolchain to the
+is by the inimitable [Catherine "whitequark"](https://github.com/whitequark),
+who has [ported the YoWASP FPGA toolchain to the
 browser](https://mastodon.social/@whitequark/111632628704217359) using Jco.
 [This project](https://vscode.dev/github/YoWASP/toolchain-demo) enables users to
 flash FPGA hardware directly from their browser over WebUSB, and even works on

--- a/_posts/2024-02-19-jco-1.0.md
+++ b/_posts/2024-02-19-jco-1.0.md
@@ -32,10 +32,11 @@ help people navigate this, here is a quick overview of the three projects and
 what their purpose is at the time of writing:
 
 - [Javy](https://github.com/bytecodealliance/javy): A JavaScript → WASI
-toolchain built for WASI 0.1. This work predates Wasm Components.
+toolchain built for WASI 0.1. This work predates Wasm Components, but Component
+support may be added in the future.
 - [ComponentizeJS](https://github.com/bytecodealliance/ComponentizeJS): A
 JavaScript → WASI toolchain built for WASI 0.2 and Wasm Components. This project
-is newer, and less mature than Javy.
+is newer and not yet considered stable.
 - [Jco](https://github.com/bytecodealliance/jco): A comprehensive WASI compiler
 toolchain and runtime for JavaScript. This includes a WASI → JS toolchain built
 for WASI 0.2 and Wasm Components.
@@ -211,12 +212,15 @@ Transpiled JS Component Files:
 ```
 
 The next step is to import this into our Node.js file. In order to do this, we
-first have to update our `package.json` to declare that we're writing a JS
-module. In our package.json, add the following line:
+first have to update our `package.json` to declare that we're writing an ES
+module. In our `package.json` set the field `"type"` to `"module"`:
 
 ```json
 {
-  "type": "module",
+  "name": "playground-jco",
+  "version": "1.0.0",
+  "type": "module",          // ← Add this line
+  // ...
 }
 ```
 

--- a/_posts/2024-02-19-jco-1.0.md
+++ b/_posts/2024-02-19-jco-1.0.md
@@ -121,13 +121,15 @@ you, please check a different location to see whether it might be somewhere else
 ### Writing a Rust library
 
 As mentioned, we're using the `cargo-component` tool here in this example to
-compile our Rust code to Wasm Components. It isn't yet at 1.0, but it *does*
-work pretty well. So we'll show you how you can use it today. If you're from the
-future (e.g. not February 2024), please check the `cargo-component` docs to see
-whether these instructions have changed, and if so - follow those instead.
-Roughly speaking what we're going to do is: take `.wit` definitions in, produce
-Rust code out. And then fill out the implementations. Even in the future there
-should be a way to do that.
+compile our Rust code to Wasm Components. It isn't yet at 1.0, but it does
+already work well enough for our purposes. So we'll show you how you can use it
+today.  If you're from the future (e.g. not February 2024), please check the
+`cargo-component` docs to see whether these instructions have changed, and if so -
+follow those instead. The steps we're going to take here are: define a WIT API
+definition, generate the Rust bindings to it (e.g. Rust traits), and then
+implement those traits to implement the definitions. Even if the exact ways of
+doing this may change in the future, conceptually there will still be ways to
+do similar things.
 
 First things first: we want `cargo component` to generate the bindings for our
 WIT file. This is done via Rust traits, and it will do this automatically when
@@ -243,11 +245,19 @@ And by leveraging code generation, all of the hard FFI and data marshalling bits
 have been handled for us - enabling us to focus on what is truly important
 (screaming we want tuna).
 
-This is just a taste of what Wasm, WASI, jco, and language toolchains can do.
-The [latest version of WASI](https://bytecodealliance.org/articles/WASI-0.2)
-(0.2) provides among other things access to asynchronous sockets, timers, and
-http. Using the same broad techniques we've shown in this post, it should for example be
-possible to write your own polyglot networked applications, today.
+In this example we happened to use JavaScript and Rust in order to demo the Jco
+runtime. But what's important to understand is that this could have just as
+easily been using JavaScript and Go. Or Rust and Python. The point of the Wasm
+Components and WASI is that we can connect any number of languages to each other
+via a strongly typed ABI.
+
+In this example we've kept things pretty simple: one method which takes strings
+in, and returns strings out. However the [latest version of
+WASI](https://bytecodealliance.org/articles/WASI-0.2) (0.2) provides among other
+things access to asynchronous sockets, timers, and http. Using the same broad
+techniques we've shown in this post, it should be possible to for example write
+your networked applications using different languages, all linked to one another
+using strongly typed WIT interfaces.
 
 ## Conclusion
 

--- a/_posts/2024-02-19-jco-1.0.md
+++ b/_posts/2024-02-19-jco-1.0.md
@@ -28,8 +28,11 @@ operations for JavaScript. With Jco 1.0 we're stabilizing a Node.js runtime for
 Wasm Components, as well as a toolchain to take Wasm Components written in other
 languages and import them into JavaScript. From here on out we hope to continue
 stabilizing more features for Jco. Some features are already available
-experimentally, including native support for the browser. As well as native
-support for compiling JavaScript code into WebAssembly.
+experimentally; this includes native support for the browser, as well as native
+support for compiling JavaScript code into WebAssembly. Other features such as
+support for the [WebAssembly
+registry](https://github.com/bytecodealliance/registry) have not yet started,
+but we expect to add later.
 
 ## JavaScript Toolchains in the Bytecode Alliance
 
@@ -48,13 +51,6 @@ This project is newer and not yet considered stable.
 Component toolchain and runtime for JavaScript. This includes a Wasm Component → JS
 toolchain with full support for WASI 0.2 built using the [SpiderMonkey
 JavaScript engine](https://spidermonkey.dev).
-
-The goal is for Jco to grow into a comprehensive toolchain which takes care of
-all JavaScript and WebAssembly Component interactions. Jco already
-experimentally exposes the functionality of ComponentizeJS via the `jco
-componentize` command. And in the future we expect to add support for the
-[WebAssembly registry](https://github.com/bytecodealliance/registry/tree/main)
-too.
 
 ## Example
 

--- a/_posts/2024-02-19-jco-1.0.md
+++ b/_posts/2024-02-19-jco-1.0.md
@@ -6,33 +6,48 @@ github_name: "yoshuawuyts"
 excerpt_separator: <!--end_excerpt-->
 ---
 
-We’re happy to announce the 1.0.0 release of [jco]: a native Javascript runtime to
-run WASI 0.2.0 components in. Being 1.0.0 means jco is now considered stable,
-and at least for the foreseeable future will not be making breaking changes. It
-can natively run WASI components inside of Node.js, making it easier to combine
-components written in different programming languages with the Node.js runtime.
-Providing those components access to networking, filesystem, and other system
-APIs available in the Node.js runtime.
+We’re happy to announce the 1.0 release of [jco]: a native Javascript
+WebAssembly runtime and toolchain built for WebAssembly Components. Jco can
+natively run Wasm Components inside of Node.js, making it easier to take
+libraries written in different programming languages, and execute them using the
+Node.js runtime. And by implementing [WASI
+0.2](https://bytecodealliance.org/articles/WASI-0.2), those components can
+access the network, filesystem, and other system APIs available in the Node.js
+runtime.
 
-Work for support of WASI targeting the browser is still in-progress, but it can
-already be used experimentally. Not all APIs available on operating system
-targets can be made available to browsers. So you can expect a subset of the
-portable WASI:CLI world to be available in the browser. However, work is also
-ongoing to develop a browser-native WASI target in order to expose the full
-breadth of features. Once the browser target stabilizes we’ll be able to discuss
-that in more detail.
+Our goal is for jco to be a comprehensive tool for all Wasm-related operations
+for JavaScript. With Jco 1.0 we're stabilizing the Node.js Wasm Component
+runtime, as well as the toolchain to take Wasm Components written in other
+languages, and import them from JavaScript. What is also included but not yet
+stable are: the browser runtime for Wasm Components, and the JavaScript to Wasm
+Component compiler. This functionality can already be used experimentally, but
+needs additional work to bring it up to the standard we expect.
 
-Finally, jco can also be used to take JavaScript code, and compile it to a WASI
-0.2.0 component. This is enabled by compiling the Spidermonkey JavaScript
-runtime to WebAssembly, and using it to execute JavaScript with. See the
-componentize-js project for more details.
+## JavaScript Toolchains in the Bytecode Alliance
+
+Jco is the third JS toolchain project which is part of the bytecode alliance. To
+help people navigate this, here is a quick overview of the three projects, and
+what their purpose is:
+
+- [Javy](https://github.com/bytecodealliance/javy): A JavaScript → WASI
+toolchain built for WASI 0.1. This work predates Wasm Components.
+- [ComponentizeJS](https://github.com/bytecodealliance/ComponentizeJS): A
+JavaScript → WASI toolchain built for WASI 0.2 and Wasm Components. This project
+is newer, and less mature than Javy.
+- [Jco](https://github.com/bytecodealliance/jco): A comprehensive WASI compiler
+toolchain and runtime for JavaScript. This includes a WASI → JS toolchain built
+for WASI 0.2 and Wasm Components.
+
+The goal is for Jco to be the only toolchain you need when working with
+JavaScript/TypeScript and WASI. And in the future we intend to stabilize the
+`jco componentize` subcommand which uses the ComponentizeJS project internally.
 
 ## Example
 
 To give you a taste of what it's like to use jco, let’s compile a little Rust
 program to a WASI 0.2.0 component, install jco for Node.js, and then embed the
 newly built component inside of the runtime. If you want to skip ahead to the
-final result, you can view it here.
+final result, you can [view it here](https://github.com/yoshuawuyts/playground-jco).
 
 ### Dependencies and Repository
 
@@ -43,29 +58,29 @@ install [`cargo-component`](https://github.com/bytecodealliance/cargo-component)
 to build our Rust code, and [jco] to build it for Node.js.
 
 ```bash
-$ npm install -g @bytecodealliance/jco        # install the jco cli tool
-$ npm install @bytecodealliance/preview2-shim # install the jco WASI runtime as a local dep
-$ cargo install cargo-component               # install the `cargo component` subcommand
+$ npm install -g @bytecodealliance/jco        # Install the jco cli tool
+$ npm install @bytecodealliance/preview2-shim # Install the jco WASI runtime as a local dep
+$ cargo install cargo-component               # Install the `cargo component` subcommand
 ```
 
 We can then proceed to create a new project repository, which has both Rust and JS code:
 
 ```sh
-$ cargo component new playground-jco --lib # create a new Rust component
-$ cd playground-jco                        # enter the newly created project
-$ npm init -y                              # setup a Node.js environment
-$ touch index.js                           # create a JS entrypoint
-$ echo node_modules >> .gitignore          # add node_modules to our .gitignore file
+$ cargo component new playground-jco --lib # Create a new Rust component
+$ cd playground-jco                        # Enter the newly created project
+$ npm init -y                              # Setup a Node.js environment
+$ touch index.js                           # Create a JS entrypoint
+$ echo node_modules >> .gitignore          # Add node_modules to our .gitignore file
 ```
 
 This should leave you with a structure that roughly looks like this:
 
 ```bash
-src/lib.rs                  # Our Rust library entry point
-wit/world.wit               # Contains our WIT IDL definitions
-Cargo.toml                  # Configures our Rust project
-index.js                    # Our JS binary entry point
-package.json                # Configures our JS Project
+src/lib.rs      # Our Rust library entry point
+wit/world.wit   # Contains our WIT IDL definitions
+Cargo.toml      # Configures our Rust project
+index.js        # Our JS binary entry point
+package.json    # Configures our JS Project
 ```
 
 And with that out of the way, we're ready to begin writing some code!
@@ -77,7 +92,7 @@ Rust code to be exported, and writing the JS code to be imported. We'll be
 starting with the WIT interface. For those of you new to Wasm Components: WIT is
 an Interface Definition Language (IDL) which allows you to describe programming
 interfaces in a declarative, language agnostic way. Let's define an interface
-which takes a regular string, and converts it to [SCREAMING_SNAKE_CASE](https://docs.rs/convert_case/latest/convert_case/enum.Case.html#variant.ScreamingSnake).
+which takes a regular string, and converts it to [SHOUTING CASE!!1!](https://github.com/badboy/stdshout).
 
 ```wit
 package my-org:wit-playground
@@ -87,11 +102,14 @@ world playground {
 }
 ```
 
-We can save this to the generated `wit/world.wit` file [^cc-gen], and now we have defined
-a function `scream` which takes a string, and returns a string. And with that,
-it's time to write our Rust code!
+We can save this to the generated `wit/world.wit` file [^cc-gen], and now we
+have defined a function `scream` which takes a string, and returns a string. And
+with that, it's time to write our Rust code!
 
-[^cc-gen]: If you're from the future: `cargo-component` generated.
+[^cc-gen]: If you're from the future: `cargo-component` generated this file for
+us in this location. Since it is not yet advertised as "stable", the output
+location for WIT files may change. If no `wit/world.wit` file was generated for
+you, please check a different location to see whether it might be somewhere else.
 
 ### Writing a Rust library
 
@@ -105,7 +123,8 @@ implementations. Even in the future there should be a way to do that.
 
 First things first: we want `cargo component` to generate the bindings for our
 WIT file. This is done via Rust traits, and it will do this automatically when
-we compile. This will yield a compiler error, but that's okay - we'll update the code in a second:
+we compile. This will yield a compiler error, but that's okay - we'll update the
+code in a second:
 
 ```bash
 $ cargo component check
@@ -114,23 +133,27 @@ $ cargo component check
 This will have generated Rust bindings, which on the current version of
 `cargo-component` is places under `lib/bindings.rs`. Don't worry about reading
 that code right now - it does a lot of heavy lifting so we don't have to. The
-important part is that it provides us with traits which we can implement. So let's implement those in our code, and write a little upper case function
+important part is that it provides us with traits which we can implement. So
+let's implement those in our code, and write a little upper case function
 
 ```rust
-mod bindings;                                     // teach our program about `src/bindings.rs`
+mod bindings;                                     // Teach our program about `src/bindings.rs`
 
-use bindings::Guest;                              // import the trait repr of our WIT world
-use wit_bindgen::rt::string::String as WitString; // import the WIT string type
+use bindings::Guest;                              // Import the trait repr of our WIT world
+use wit_bindgen::rt::string::String as WitString; // Import the WIT string type
 
-struct Component;                                 // define the type to export
-impl Guest for Component {                        // import the WIT world + methods
-    fn scream(input: WitString) -> WitString {
-        input.to_uppercase().replace(' ', "_").into() // not perfect, but good enough for this example
+struct Component;                                 // Define the type to export
+impl Guest for Component {                        // Import the WIT world + methods
+    fn scream(input: WitString) -> WitString {    // Implement our `scream` method
+        let mut s = input.to_uppercase();
+        s.push_str("!!1!");
+        s.into()
     }
 }
 ```
 
-Now if we re-run `cargo component check`, it should compile without any warnings. That means we're ready to run:
+Now if we re-run `cargo component check`, it should compile without any
+warnings. That means we're ready to run:
 
 ```bash
 $ cargo component build      # Compile our Rust library to a Wasm Component
@@ -150,9 +173,9 @@ JS bindings from it. We can do this using the `jco transpile command`. Let's
 point it at our newly generated Wasm library, like so:
 
 ```bash
-$ jco transpile \                                   # call jco transpile
-    target/wasm32-wasi/debug/playground_jco.wasm \  # point it at our Rust library
-    -o target/jco                                   # write the result to `target/jco`
+$ jco transpile \                                   # Call jco transpile
+    target/wasm32-wasi/debug/playground_jco.wasm \  # Point it at our Rust library
+    -o target/jco                                   # Write the result to `target/jco`
 ```
 
 On success it will tell you it's generated a number of JS files as part of
@@ -201,7 +224,7 @@ console.log(msg);
 Now if we run this using `node index.js`, we should get the following output:
 
 ```text
-CHASHU_WOULD_LIKE_SOME_TUNA
+CHASHU WOULD LIKE SOME TUNA!!1!
 ```
 
 And with that, we've successfully written our first Rust component for Node.js.
@@ -226,8 +249,17 @@ features are currently in progress, as well as future directions. Finally we’v
 shown an example of how to use jco to embed a Rust library inside of a Node.js
 project.
 
+We're happy to report that several projects in the wild are already succesfully
+using Jco to build their projects with. One particularly impressive project 
+is by the inimitable [Whitequark](https://github.com/whitequark), who has
+[ported the YoWASP FPGA toolchain to the
+browser](https://mastodon.social/@whitequark/111632628704217359) using Jco.
+[This project](https://vscode.dev/github/YoWASP/toolchain-demo) enables users to
+flash FPGA hardware directly from their browser over WebUSB, and even works on
+mobile devices.
+
 Jco is a Bytecode Alliance project, designed and led by Guy Bedford (Fastly).
-The 1.0.0 release of Jco was made possible with the assistance of Pat Hickey
+The 1.0 release of Jco was made possible with the assistance of Pat Hickey
 (Fastly), Wassim Chegham (Microsoft), Dirk Bäumer (Microsoft), and Yosh Wuyts
 (Microsoft). On behalf of the Bytecode Alliance, we’d like to thank everyone who
 was involved with the conception, design, and development of jco. And we’re very

--- a/_posts/2024-02-19-jco-1.0.md
+++ b/_posts/2024-02-19-jco-1.0.md
@@ -43,8 +43,9 @@ install [`cargo-component`](https://github.com/bytecodealliance/cargo-component)
 to build our Rust code, and [jco] to build it for Node.js.
 
 ```bash
-$ npm install -g @bytecodealliance/jco  # install the jco cli tool
-$ cargo install cargo-component         # install the `cargo component` subcommand
+$ npm install -g @bytecodealliance/jco        # install the jco cli tool
+$ npm install @bytecodealliance/preview2-shim # install the jco WASI runtime as a local dep
+$ cargo install cargo-component               # install the `cargo component` subcommand
 ```
 
 We can then proceed to create a new project repository, which has both Rust and JS code:
@@ -76,7 +77,7 @@ Rust code to be exported, and writing the JS code to be imported. We'll be
 starting with the WIT interface. For those of you new to Wasm Components: WIT is
 an Interface Definition Language (IDL) which allows you to describe programming
 interfaces in a declarative, language agnostic way. Let's define an interface
-which takes a string, and converts it to [SCREAMING_SNAKE_CASE](https://docs.rs/convert_case/latest/convert_case/enum.Case.html#variant.ScreamingSnake).
+which takes a regular string, and converts it to [SCREAMING_SNAKE_CASE](https://docs.rs/convert_case/latest/convert_case/enum.Case.html#variant.ScreamingSnake).
 
 ```wit
 package my-org:wit-playground
@@ -92,7 +93,7 @@ it's time to write our Rust code!
 
 [^cc-gen]: If you're from the future: `cargo-component` generated.
 
-### Defining the Rust library
+### Writing a Rust library
 
 As mentioned, we're using the `cargo-component` tool here in this example to
 compile our Rust code to Wasm Components. It isn't yet at 1.0, but it *does*
@@ -124,7 +125,7 @@ use wit_bindgen::rt::string::String as WitString; // import the WIT string type
 struct Component;                                 // define the type to export
 impl Guest for Component {                        // import the WIT world + methods
     fn scream(input: WitString) -> WitString {
-        input.to_uppercase().replace(' ', "_").into()
+        input.to_uppercase().replace(' ', "_").into() // not perfect, but good enough for this example
     }
 }
 ```
@@ -135,8 +136,87 @@ Now if we re-run `cargo component check`, it should compile without any warnings
 $ cargo component build      # Compile our Rust library to a Wasm Component
 ```
 
-### Defining the JS binary
+This will have written the generated Wasm code to
+`target/wasm32-wasi/debug/playground_jco.wasm`. Once Rust lands support for a
+native Preview 2 target, expect this to change to
+`target/wasm32-wasi-p2/debug/playground_jco.wasm` or similar, as the current set
+of workarounds will no longer be needed (important if you're reading this
+anytime after March 2024 or so).
 
+### Writing a JavaScript binary
+
+Okay, it's time to use `jco`. First we want to take our Rust code, and generate
+JS bindings from it. We can do this using the `jco transpile command`. Let's
+point it at our newly generated Wasm library, like so:
+
+```bash
+$ jco transpile \                                   # call jco transpile
+    target/wasm32-wasi/debug/playground_jco.wasm \  # point it at our Rust library
+    -o target/jco                                   # write the result to `target/jco`
+```
+
+On success it will tell you it's generated a number of JS files as part of
+its CLI output:
+
+```text
+Transpiled JS Component Files:
+
+ - target/jco/interfaces/wasi-cli-environment.d.ts      0.09 KiB
+ - target/jco/interfaces/wasi-cli-exit.d.ts             0.16 KiB
+ - target/jco/interfaces/wasi-cli-stderr.d.ts           0.17 KiB
+ - target/jco/interfaces/wasi-cli-stdin.d.ts            0.17 KiB
+ - target/jco/interfaces/wasi-cli-stdout.d.ts           0.17 KiB
+ - target/jco/interfaces/wasi-clocks-wall-clock.d.ts    0.11 KiB
+ - target/jco/interfaces/wasi-filesystem-preopens.d.ts   0.2 KiB
+ - target/jco/interfaces/wasi-filesystem-types.d.ts     2.71 KiB
+ - target/jco/interfaces/wasi-io-error.d.ts             0.08 KiB
+ - target/jco/interfaces/wasi-io-streams.d.ts           0.58 KiB
+ - target/jco/playground_jco.core.wasm                  1.83 MiB
+ - target/jco/playground_jco.core2.wasm                 16.5 KiB
+ - target/jco/playground_jco.d.ts                       0.72 KiB
+ - target/jco/playground_jco.js                           40 KiB
+```
+
+The next step is to import this into our Node.js file. In order to do this, we
+first have to update our `package.json` to declare that we're writing a JS
+module. In our package.json, add the following line:
+
+```json
+{
+  "type": "module",
+}
+```
+
+And then finally, we're ready to write some JS code. we're going to import the
+`scream` function from our Rust library, pass it a string, and then print the
+output of the string.
+
+```js
+import { scream } from "./target/jco/playground_jco.js";
+
+let msg = scream("chashu would like some tuna");
+console.log(msg);
+```
+
+Now if we run this using `node index.js`, we should get the following output:
+
+```text
+CHASHU_WOULD_LIKE_SOME_TUNA
+```
+
+And with that, we've successfully written our first Rust component for Node.js.
+You can give yourself a little round of applause - because this is *incredibly
+cool*! By leveraging WIT and Wasm, we've been able to define a language-agnostic
+interface which resulted in strongly typed code for both programming languages.
+And by leveraging code generation, all of the hard FFI and data marshalling bits
+have been handled for us - enabling us to focus on what is truly important
+(screaming we want tuna).
+
+This is just a taste of what Wasm, WASI, jco, and language toolchains can do.
+The [latest version of WASI](https://bytecodealliance.org/articles/WASI-0.2)
+(0.2.0) provides among other things access to asynchronous sockets, timers, and
+http. Using the same broad techniques we've shown in this post, it should for example be
+possible to write your own polyglot networked applications, today.
 
 ## Conclusion
 
@@ -145,9 +225,6 @@ run WASI 0.2.0 components. We’ve discussed what has been stabilized, which
 features are currently in progress, as well as future directions. Finally we’ve
 shown an example of how to use jco to embed a Rust library inside of a Node.js
 project.
-
-TODO: mention async and the Rust ecosystem not being ready yet. As well as other
-language toolchains still being in-progress.
 
 Jco is a Bytecode Alliance project, designed and led by Guy Bedford (Fastly).
 The 1.0.0 release of Jco was made possible with the assistance of Pat Hickey

--- a/_posts/2024-02-19-jco-1.0.md
+++ b/_posts/2024-02-19-jco-1.0.md
@@ -28,9 +28,8 @@ operations for JavaScript. With Jco 1.0 we're stabilizing a Node.js runtime for
 Wasm Components, as well as a toolchain to take Wasm Components written in other
 languages and import them into JavaScript. From here on out we hope to continue
 stabilizing more features for Jco. Some features are already available
-experimentally, including: native support for browser and Deno.js JavaScript
-runtimes. As well as native support for compiling JavaScript code into
-WebAssembly.
+experimentally, including native support for the browser. As well as native
+support for compiling JavaScript code into WebAssembly.
 
 ## JavaScript Toolchains in the Bytecode Alliance
 
@@ -38,23 +37,24 @@ Jco is the third JS toolchain project which is part of the Bytecode Alliance. To
 help people navigate this, here is a quick overview of the three projects and
 what their purpose is at the time of writing:
 
-- [Javy](https://github.com/bytecodealliance/javy): A JavaScript → WASI
-compiler toolchain built for WASI 0.1 using the [QuickJS JavaScript
+- [Javy](https://github.com/bytecodealliance/javy): A JavaScript → WASI 0.1
+compiler toolchain built using the [QuickJS JavaScript
 engine](https://bellard.org/quickjs/). This work predates Wasm Components, but
-Component support may be added in the future.
+support may be added in the future.
 - [ComponentizeJS](https://github.com/bytecodealliance/ComponentizeJS): A
-JavaScript → WASI compiler toolchain built for WASI 0.2 and Wasm Components.
+JavaScript → Wasm Component compiler toolchain with full support for WASI 0.2.
 This project is newer and not yet considered stable.
-- [Jco](https://github.com/bytecodealliance/jco): A comprehensive WASI compiler
-toolchain and runtime for JavaScript. This includes a WASI → JS toolchain built
-for WASI 0.2 and Wasm Components using the [SpiderMonkey JavaScript
-engine](https://spidermonkey.dev).
+- [Jco](https://github.com/bytecodealliance/jco): A comprehensive WebAssembly
+Component toolchain and runtime for JavaScript. This includes a Wasm Component → JS
+toolchain with full support for WASI 0.2 built using the [SpiderMonkey
+JavaScript engine](https://spidermonkey.dev).
 
 The goal is for Jco to grow into a comprehensive toolchain which takes care of
-all JavaScript and WebAssembly interactions. Jco already experimentally exposes
-the functionality of ComponentizeJS via the `jco componentize` command. And in
-the future we expect to add support for the [WebAssembly
-registry](https://github.com/bytecodealliance/registry/tree/main) too.
+all JavaScript and WebAssembly Component interactions. Jco already
+experimentally exposes the functionality of ComponentizeJS via the `jco
+componentize` command. And in the future we expect to add support for the
+[WebAssembly registry](https://github.com/bytecodealliance/registry/tree/main)
+too.
 
 ## Example
 

--- a/_posts/2024-02-19-jco-1.0.md
+++ b/_posts/2024-02-19-jco-1.0.md
@@ -6,7 +6,7 @@ github_name: "yoshuawuyts"
 excerpt_separator: <!--end_excerpt-->
 ---
 
-We’re happy to announce the 1.0.0 release of jco: a native Javascript runtime to
+We’re happy to announce the 1.0.0 release of [jco]: a native Javascript runtime to
 run WASI 0.2.0 components in. Being 1.0.0 means jco is now considered stable,
 and at least for the foreseeable future will not be making breaking changes. It
 can natively run WASI components inside of Node.js, making it easier to combine
@@ -34,7 +34,109 @@ program to a WASI 0.2.0 component, install jco for Node.js, and then embed the
 newly built component inside of the runtime. If you want to skip ahead to the
 final result, you can view it here.
 
-[example goes here]
+### Dependencies and Repository
+
+Because we're going to be writing Rust code, and using it from Node.js we expect
+you to have both a working [Node.js environment](https://github.com/nvm-sh/nvm)
+and [Rust toolchain](https://rustup.rs) installed. Once you have that, we can
+install [`cargo-component`](https://github.com/bytecodealliance/cargo-component)
+to build our Rust code, and [jco] to build it for Node.js.
+
+```bash
+$ npm install -g @bytecodealliance/jco  # install the jco cli tool
+$ cargo install cargo-component         # install the `cargo component` subcommand
+```
+
+We can then proceed to create a new project repository, which has both Rust and JS code:
+
+```sh
+$ cargo component new playground-jco --lib # create a new Rust component
+$ cd playground-jco                        # enter the newly created project
+$ npm init -y                              # setup a Node.js environment
+$ touch index.js                           # create a JS entrypoint
+$ echo node_modules >> .gitignore          # add node_modules to our .gitignore file
+```
+
+This should leave you with a structure that roughly looks like this:
+
+```bash
+src/lib.rs                  # Our Rust library entry point
+wit/world.wit               # Contains our WIT IDL definitions
+Cargo.toml                  # Configures our Rust project
+index.js                    # Our JS binary entry point
+package.json                # Configures our JS Project
+```
+
+And with that out of the way, we're ready to begin writing some code!
+
+### Defining the WIT interface
+
+There are three steps to this project: defining the WIT interface, writing the
+Rust code to be exported, and writing the JS code to be imported. We'll be
+starting with the WIT interface. For those of you new to Wasm Components: WIT is
+an Interface Definition Language (IDL) which allows you to describe programming
+interfaces in a declarative, language agnostic way. Let's define an interface
+which takes a string, and converts it to [SCREAMING_SNAKE_CASE](https://docs.rs/convert_case/latest/convert_case/enum.Case.html#variant.ScreamingSnake).
+
+```wit
+package my-org:wit-playground
+
+world playground {
+  export scream: func(input: string) -> string;
+}
+```
+
+We can save this to the generated `wit/world.wit` file [^cc-gen], and now we have defined
+a function `scream` which takes a string, and returns a string. And with that,
+it's time to write our Rust code!
+
+[^cc-gen]: If you're from the future: `cargo-component` generated.
+
+### Defining the Rust library
+
+As mentioned, we're using the `cargo-component` tool here in this example to
+compile our Rust code to Wasm Components. It isn't yet at 1.0, but it *does*
+work pretty well. So we'll show you how you can use it today. If you're from the
+future (e.g. not February 2024), please check the `cargo-component` docs to see
+how to follow these steps. Roughly speaking what we're going to do is: take
+`.wit` definitions in, produce Rust code out. And then fill out the
+implementations. Even in the future there should be a way to do that.
+
+First things first: we want `cargo component` to generate the bindings for our
+WIT file. This is done via Rust traits, and it will do this automatically when
+we compile. This will yield a compiler error, but that's okay - we'll update the code in a second:
+
+```bash
+$ cargo component check
+```
+
+This will have generated Rust bindings, which on the current version of
+`cargo-component` is places under `lib/bindings.rs`. Don't worry about reading
+that code right now - it does a lot of heavy lifting so we don't have to. The
+important part is that it provides us with traits which we can implement. So let's implement those in our code, and write a little upper case function
+
+```rust
+mod bindings;                                     // teach our program about `src/bindings.rs`
+
+use bindings::Guest;                              // import the trait repr of our WIT world
+use wit_bindgen::rt::string::String as WitString; // import the WIT string type
+
+struct Component;                                 // define the type to export
+impl Guest for Component {                        // import the WIT world + methods
+    fn scream(input: WitString) -> WitString {
+        input.to_uppercase().replace(' ', "_").into()
+    }
+}
+```
+
+Now if we re-run `cargo component check`, it should compile without any warnings. That means we're ready to run:
+
+```bash
+$ cargo component build      # Compile our Rust library to a Wasm Component
+```
+
+### Defining the JS binary
+
 
 ## Conclusion
 
@@ -44,9 +146,14 @@ features are currently in progress, as well as future directions. Finally we’v
 shown an example of how to use jco to embed a Rust library inside of a Node.js
 project.
 
+TODO: mention async and the Rust ecosystem not being ready yet. As well as other
+language toolchains still being in-progress.
+
 Jco is a Bytecode Alliance project, designed and led by Guy Bedford (Fastly).
 The 1.0.0 release of Jco was made possible with the assistance of Pat Hickey
 (Fastly), Wassim Chegham (Microsoft), Dirk Bäumer (Microsoft), and Yosh Wuyts
 (Microsoft). On behalf of the Bytecode Alliance, we’d like to thank everyone who
 was involved with the conception, design, and development of jco. And we’re very
 excited for people to be able to start using it in their projects!
+
+[jco]: https://github.com/bytecodealliance/jco

--- a/_posts/2024-02-19-jco-1.0.md
+++ b/_posts/2024-02-19-jco-1.0.md
@@ -276,7 +276,7 @@ browser](https://mastodon.social/@whitequark/111632628704217359) using Jco.
 flash FPGA hardware directly from their browser over WebUSB, and even works on
 mobile devices.
 
-Jco is a Bytecode Alliance project, designed and led by Guy Bedford (Fastly).
+[Jco][jco] is a Bytecode Alliance project, designed and led by Guy Bedford (Fastly).
 The 1.0 release of Jco was made possible with the assistance of Pat Hickey
 (Fastly), Wassim Chegham (Microsoft), Dirk Bäumer (Microsoft), and Yosh Wuyts
 (Microsoft). On behalf of the Bytecode Alliance, we’d like to thank everyone who

--- a/_posts/2024-02-19-jco-1.0.md
+++ b/_posts/2024-02-19-jco-1.0.md
@@ -6,24 +6,31 @@ github_name: "yoshuawuyts"
 excerpt_separator: <!--end_excerpt-->
 ---
 
-We’re happy to announce the 1.0 release of [jco]: a native Javascript
-WebAssembly runtime and toolchain built for WebAssembly Components. Jco can
-natively run Wasm Components inside of Node.js, making it easier to take
-libraries written in different programming languages and execute them using the
-Node.js runtime. And by implementing [WASI
-0.2](https://bytecodealliance.org/articles/WASI-0.2), those components can
-access the network, filesystem, and other system APIs available in the Node.js
-runtime.
+We’re happy to announce the 1.0 release of [Jco][jco]: a native Javascript
+WebAssembly toolchain and runtime built for WebAssembly Components and [WASI
+0.2](https://bytecodealliance.org/articles/WASI-0.2) [^wasi-one-liner]. Jco can
+natively run Wasm Components inside of Node.js, making it easy to take libraries
+written in different programming languages and execute them using the Node.js
+runtime. And by implementing the entirety of the WASI 0.2 API surface, those
+components can access the network, filesystem, and other system APIs available
+in the Node.js runtime.
+
+[^wasi-one-liner]: WebAssembly Components are an extension to WebAssembly to
+create strongly typed interfaces between different programs. WASI 0.2 is a
+re-work of the "WebAssembly System Interfaces" based on WebAssembly Components.
+The previous version of WASI was not based on components, and as a result was
+rather limited in what it could express.
 
 <!--end_excerpt-->
 
-Our goal is for jco to be a comprehensive tool for all Wasm-related operations
-for JavaScript. With Jco 1.0 we're stabilizing the Node.js Wasm Component
-runtime, as well as the toolchain to take Wasm Components written in other
-languages and import them from JavaScript. What is also included but not yet
-stable are: the browser runtime for Wasm Components and the JavaScript to Wasm
-Component compiler. This functionality can already be used experimentally, but
-needs additional work to bring it up to the standard we expect.
+Our goal is for Jco to be a comprehensive tool for all Component-related
+operations for JavaScript. With Jco 1.0 we're stabilizing a Node.js runtime for
+Wasm Components, as well as a toolchain to take Wasm Components written in other
+languages and import them into JavaScript. From here on out we hope to continue
+stabilizing more features for Jco. Some features are already available
+experimentally, including: native support for browser and Deno.js JavaScript
+runtimes. As well as native support for compiling JavaScript code into
+WebAssembly.
 
 ## JavaScript Toolchains in the Bytecode Alliance
 
@@ -42,14 +49,14 @@ toolchain and runtime for JavaScript. This includes a WASI → JS toolchain buil
 for WASI 0.2 and Wasm Components.
 
 The goal is for Jco to eventually evolve into a comprehensive toolchain for all
-WASI and JavaScript needs. The command `jco componentize` uses ComponentizeJS
-under the covers, so as jco matures you shouldn't have to think about
-ComponentizeJS much, if at all.
+WASI support and JavaScript Component needs. The command `jco componentize` uses
+ComponentizeJS under the covers, so as jco matures you shouldn't have to think
+about ComponentizeJS much, if at all.
 
 ## Example
 
-To give you a taste of what it's like to use jco, let’s compile a little Rust
-program to a WASI 0.2.0 component, install jco for Node.js, and then embed the
+To give you a taste of what it's like to use Jco, let’s compile a little Rust
+program to a WASI 0.2.0 component, install Jco for Node.js, and then embed the
 newly built component inside of the runtime. If you want to skip ahead to the
 final result, you can [view it here](https://github.com/yoshuawuyts/playground-jco).
 
@@ -59,7 +66,7 @@ Because we're going to be writing Rust code, and using it from Node.js we expect
 you to have both a working [Node.js environment](https://github.com/nvm-sh/nvm)
 and [Rust toolchain](https://rustup.rs) installed. Once you have that, we can
 install [`cargo-component`](https://github.com/bytecodealliance/cargo-component)
-to build our Rust code, and [jco] to build it for Node.js.
+to build our Rust code, and [Jco][jco] to build it for Node.js.
 
 ```bash
 $ npm install -g @bytecodealliance/jco        # Install the jco cli tool
@@ -96,7 +103,8 @@ Rust code to be exported, and writing the JS code to be imported. We'll be
 starting with the WIT interface. For those of you new to Wasm Components: WIT is
 an Interface Description Language (IDL) which allows you to describe programming
 interfaces in a declarative, language agnostic way. Let's define an interface
-which takes a regular string, and converts it to [SHOUTING CASE!!1!](https://github.com/badboy/stdshout).
+which takes a regular string, and converts it to [SHOUTING
+CASE!!1!](https://github.com/badboy/stdshout).
 
 ```wit
 package my-org:wit-playground
@@ -179,12 +187,12 @@ anytime after March 2024 or so).
 
 ### Writing a JavaScript binary
 
-Okay, it's time to use `jco`. First we want to take our Rust code, and generate
+Okay, it's time to use Jco. First we want to take our Rust code, and generate
 JS bindings from it. We can do this using the `jco transpile command`. Let's
 point it at our newly generated Wasm library, like so:
 
 ```bash
-$ jco transpile \                                   # Call jco transpile
+$ jco transpile \                                   # Call `jco transpile`
     target/wasm32-wasi/debug/playground_jco.wasm \  # Point it at our Rust library
     -o target/jco                                   # Write the result to `target/jco`
 ```
@@ -265,10 +273,10 @@ using strongly typed WIT interfaces.
 
 ## Conclusion
 
-In this post we’ve introduce jco 1.0.0: a native JavaScript runtime which can
+In this post we’ve introduce Jco 1.0.0: a native JavaScript runtime which can
 run WASI 0.2 components. We’ve discussed what has been stabilized, which
 features are currently in progress, as well as future directions. Finally we’ve
-shown an example of how to use jco to embed a Rust library inside of a Node.js
+shown an example of how to use Jco to embed a Rust library inside of a Node.js
 project.
 
 We're happy to report that several projects in the wild are already succesfully
@@ -284,7 +292,7 @@ mobile devices.
 The 1.0 release of Jco was made possible with the assistance of Pat Hickey
 (Fastly), Wassim Chegham (Microsoft), Dirk Bäumer (Microsoft), and Yosh Wuyts
 (Microsoft). On behalf of the Bytecode Alliance, we’d like to thank everyone who
-was involved with the conception, design, and development of jco. And we’re very
+was involved with the conception, design, and development of Jco. And we’re very
 excited for people to be able to start using it in their projects!
 
 [jco]: https://github.com/bytecodealliance/jco

--- a/_posts/2024-02-19-jco-1.0.md
+++ b/_posts/2024-02-19-jco-1.0.md
@@ -9,7 +9,7 @@ excerpt_separator: <!--end_excerpt-->
 We’re happy to announce the 1.0 release of [jco]: a native Javascript
 WebAssembly runtime and toolchain built for WebAssembly Components. Jco can
 natively run Wasm Components inside of Node.js, making it easier to take
-libraries written in different programming languages, and execute them using the
+libraries written in different programming languages and execute them using the
 Node.js runtime. And by implementing [WASI
 0.2](https://bytecodealliance.org/articles/WASI-0.2), those components can
 access the network, filesystem, and other system APIs available in the Node.js
@@ -20,16 +20,16 @@ runtime.
 Our goal is for jco to be a comprehensive tool for all Wasm-related operations
 for JavaScript. With Jco 1.0 we're stabilizing the Node.js Wasm Component
 runtime, as well as the toolchain to take Wasm Components written in other
-languages, and import them from JavaScript. What is also included but not yet
-stable are: the browser runtime for Wasm Components, and the JavaScript to Wasm
+languages and import them from JavaScript. What is also included but not yet
+stable are: the browser runtime for Wasm Components and the JavaScript to Wasm
 Component compiler. This functionality can already be used experimentally, but
 needs additional work to bring it up to the standard we expect.
 
 ## JavaScript Toolchains in the Bytecode Alliance
 
-Jco is the third JS toolchain project which is part of the bytecode alliance. To
-help people navigate this, here is a quick overview of the three projects, and
-what their purpose is:
+Jco is the third JS toolchain project which is part of the Bytecode Alliance. To
+help people navigate this, here is a quick overview of the three projects and
+what their purpose is at the time of writing:
 
 - [Javy](https://github.com/bytecodealliance/javy): A JavaScript → WASI
 toolchain built for WASI 0.1. This work predates Wasm Components.
@@ -40,9 +40,10 @@ is newer, and less mature than Javy.
 toolchain and runtime for JavaScript. This includes a WASI → JS toolchain built
 for WASI 0.2 and Wasm Components.
 
-The goal is for Jco to be the only toolchain you need when working with
-JavaScript/TypeScript and WASI. And in the future we intend to stabilize the
-`jco componentize` subcommand which uses the ComponentizeJS project internally.
+The goal is for Jco to eventually evolve into a comprehensive toolchain for all
+WASI and JavaScript needs. The command `jco componentize` uses ComponentizeJS
+under the covers, so as jco matures you shouldn't have to think about
+ComponentizeJS much, if at all.
 
 ## Example
 
@@ -92,7 +93,7 @@ And with that out of the way, we're ready to begin writing some code!
 There are three steps to this project: defining the WIT interface, writing the
 Rust code to be exported, and writing the JS code to be imported. We'll be
 starting with the WIT interface. For those of you new to Wasm Components: WIT is
-an Interface Definition Language (IDL) which allows you to describe programming
+an Interface Description Language (IDL) which allows you to describe programming
 interfaces in a declarative, language agnostic way. Let's define an interface
 which takes a regular string, and converts it to [SHOUTING CASE!!1!](https://github.com/badboy/stdshout).
 
@@ -105,8 +106,12 @@ world playground {
 ```
 
 We can save this to the generated `wit/world.wit` file [^cc-gen], and now we
-have defined a function `scream` which takes a string, and returns a string. And
-with that, it's time to write our Rust code!
+have defined a function `scream` which takes a string, and returns a string. If
+this is your first time editing WIT files and you're using VS Code, consider
+installing the [WIT
+IDL](https://marketplace.visualstudio.com/items?itemName=bytecodealliance.wit-idl)
+package to get editor support for WIT files. And with that, it's time to write
+our Rust code!
 
 [^cc-gen]: If you're from the future: `cargo-component` generated this file for
 us in this location. Since it is not yet advertised as "stable", the output
@@ -119,9 +124,10 @@ As mentioned, we're using the `cargo-component` tool here in this example to
 compile our Rust code to Wasm Components. It isn't yet at 1.0, but it *does*
 work pretty well. So we'll show you how you can use it today. If you're from the
 future (e.g. not February 2024), please check the `cargo-component` docs to see
-how to follow these steps. Roughly speaking what we're going to do is: take
-`.wit` definitions in, produce Rust code out. And then fill out the
-implementations. Even in the future there should be a way to do that.
+whether these instructions have changed, and if so - follow those instead.
+Roughly speaking what we're going to do is: take `.wit` definitions in, produce
+Rust code out. And then fill out the implementations. Even in the future there
+should be a way to do that.
 
 First things first: we want `cargo component` to generate the bindings for our
 WIT file. This is done via Rust traits, and it will do this automatically when
@@ -163,7 +169,7 @@ $ cargo component build      # Compile our Rust library to a Wasm Component
 
 This will have written the generated Wasm code to
 `target/wasm32-wasi/debug/playground_jco.wasm`. Once Rust lands support for a
-native Preview 2 target, expect this to change to
+native WASI 0.2 target, expect this to change to
 `target/wasm32-wasi-p2/debug/playground_jco.wasm` or similar, as the current set
 of workarounds will no longer be needed (important if you're reading this
 anytime after March 2024 or so).
@@ -239,14 +245,14 @@ have been handled for us - enabling us to focus on what is truly important
 
 This is just a taste of what Wasm, WASI, jco, and language toolchains can do.
 The [latest version of WASI](https://bytecodealliance.org/articles/WASI-0.2)
-(0.2.0) provides among other things access to asynchronous sockets, timers, and
+(0.2) provides among other things access to asynchronous sockets, timers, and
 http. Using the same broad techniques we've shown in this post, it should for example be
 possible to write your own polyglot networked applications, today.
 
 ## Conclusion
 
 In this post we’ve introduce jco 1.0.0: a native JavaScript runtime which can
-run WASI 0.2.0 components. We’ve discussed what has been stabilized, which
+run WASI 0.2 components. We’ve discussed what has been stabilized, which
 features are currently in progress, as well as future directions. Finally we’ve
 shown an example of how to use jco to embed a Rust library inside of a Node.js
 project.

--- a/_posts/2024-02-19-jco-1.0.md
+++ b/_posts/2024-02-19-jco-1.0.md
@@ -1,0 +1,52 @@
+---
+title: "Announcing Jco 1.0"
+author: "Yosh Wuyts"
+date: "2024-02-19"
+github_name: "yoshuawuyts"
+excerpt_separator: <!--end_excerpt-->
+---
+
+We’re happy to announce the 1.0.0 release of jco: a native Javascript runtime to
+run WASI 0.2.0 components in. Being 1.0.0 means jco is now considered stable,
+and at least for the foreseeable future will not be making breaking changes. It
+can natively run WASI components inside of Node.js, making it easier to combine
+components written in different programming languages with the Node.js runtime.
+Providing those components access to networking, filesystem, and other system
+APIs available in the Node.js runtime.
+
+Work for support of WASI targeting the browser is still in-progress, but it can
+already be used experimentally. Not all APIs available on operating system
+targets can be made available to browsers. So you can expect a subset of the
+portable WASI:CLI world to be available in the browser. However, work is also
+ongoing to develop a browser-native WASI target in order to expose the full
+breadth of features. Once the browser target stabilizes we’ll be able to discuss
+that in more detail.
+
+Finally, jco can also be used to take JavaScript code, and compile it to a WASI
+0.2.0 component. This is enabled by compiling the Spidermonkey JavaScript
+runtime to WebAssembly, and using it to execute JavaScript with. See the
+componentize-js project for more details.
+
+## Example
+
+To give you a taste of what it's like to use jco, let’s compile a little Rust
+program to a WASI 0.2.0 component, install jco for Node.js, and then embed the
+newly built component inside of the runtime. If you want to skip ahead to the
+final result, you can view it here.
+
+[example goes here]
+
+## Conclusion
+
+In this post we’ve introduce jco 1.0.0: a native JavaScript runtime which can
+run WASI 0.2.0 components. We’ve discussed what has been stabilized, which
+features are currently in progress, as well as future directions. Finally we’ve
+shown an example of how to use jco to embed a Rust library inside of a Node.js
+project.
+
+Jco is a Bytecode Alliance project, designed and led by Guy Bedford (Fastly).
+The 1.0.0 release of Jco was made possible with the assistance of Pat Hickey
+(Fastly), Wassim Chegham (Microsoft), Dirk Bäumer (Microsoft), and Yosh Wuyts
+(Microsoft). On behalf of the Bytecode Alliance, we’d like to thank everyone who
+was involved with the conception, design, and development of jco. And we’re very
+excited for people to be able to start using it in their projects!

--- a/_posts/2024-02-19-jco-1.0.md
+++ b/_posts/2024-02-19-jco-1.0.md
@@ -272,7 +272,7 @@ using strongly typed WIT interfaces.
 
 ## Conclusion
 
-In this post we’ve introduce Jco 1.0.0: a native JavaScript runtime which can
+In this post we’ve introduced Jco 1.0.0: a native JavaScript runtime which can
 run WASI 0.2 components. We’ve discussed what has been stabilized, which
 features are currently in progress, as well as future directions. Finally we’ve
 shown an example of how to use Jco to embed a Rust library inside of a Node.js


### PR DESCRIPTION
This blog post announces the release of Jco 1.0. Thanks!

[rendered](https://github.com/yoshuawuyts/bytecodealliance.org/blob/announcing-jco/_posts/2024-02-19-jco-1.0.md).