### PR TITLE
fixup jco announcement tutorial for cargo-component-component 0.10.1

### DIFF
--- a/_posts/2024-02-19-jco-1.0.md
+++ b/_posts/2024-02-19-jco-1.0.md
@@ -77,6 +77,7 @@ $ cd playground-jco                        # Enter the newly created project
 $ npm init -y                              # Setup a Node.js environment
 $ touch index.js                           # Create a JS entrypoint
 $ echo node_modules >> .gitignore          # Add node_modules to our .gitignore file
+$ cargo add wit_bindgen                    # add cargo crate dependencies
 ```
 
 This should leave you with a structure that roughly looks like this:
@@ -102,7 +103,7 @@ which takes a regular string, and converts it to [SHOUTING
 CASE!!1!](https://github.com/badboy/stdshout).
 
 ```wit
-package my-org:wit-playground
+package my-org:wit-playground;
 
 world playground {
   export scream: func(input: string) -> string;


### PR DESCRIPTION
I ran into a few issues trying to run this tutorial against what I'm assuming are newer versions of the toolchain. Trying to do proper open source & PR in fixes, but I don't yet have a working run of the example.

## Notes so far
* I needed to add a semicolon here:
```
package my-org:wit-playground;

world playground {
  export scream: func(input: string) -> string;
}
```

* needed to `cargo add wit_bindgen`

* I get three warning after-copy-pasting code from bindings:

```shell
$ cargo component check
warning: unused import: `__export_world_playground_cabi`
  --> src/bindings.rs:44:16
   |
44 | pub(crate) use __export_world_playground_cabi;
   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused import: `__export_playground_impl as export`
  --> src/bindings.rs:95:16
   |
95 | pub(crate) use __export_playground_impl as export;
   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: function `string_lift` is never used
  --> src/bindings.rs:50:19
   |
50 |     pub unsafe fn string_lift(bytes: Vec<u8>) -> String {
   |                   ^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: function `cabi_dealloc` is never used
  --> src/bindings.rs:57:19
   |
57 |     pub unsafe fn cabi_dealloc(ptr: *mut u8, size: usize, align: usize) {
   |                   ^^^^^^^^^^^^

warning: `playground-jco` (lib) generated 4 warnings (run `cargo fix --lib -p playground-jco` to apply 2 suggestions)
    Finished dev [unoptimized + debuginfo] target(s) in 0.06s

```

ignoring the warnings & trying to compile, I get the following error:

```
$ cargo component build
  Installing wasm32-wasi target
info: downloading component 'rust-std' for 'wasm32-wasi'
info: installing component 'rust-std' for 'wasm32-wasi'
   Compiling proc-macro2 v1.0.79
   Compiling serde v1.0.197
   Compiling unicode-ident v1.0.12
   Compiling semver v1.0.22
   Compiling hashbrown v0.14.3
   Compiling equivalent v1.0.1
   Compiling anyhow v1.0.82
   Compiling serde_json v1.0.115
   Compiling bitflags v2.5.0
   Compiling ryu v1.0.17
   Compiling itoa v1.0.11
   Compiling log v0.4.21
   Compiling unicode-xid v0.2.4
   Compiling leb128 v0.2.5
   Compiling smallvec v1.13.2
   Compiling id-arena v2.2.1
   Compiling wasm-encoder v0.202.0
   Compiling unicode-segmentation v1.11.0
   Compiling wit-bindgen-rust v0.24.0
   Compiling spdx v0.10.4
   Compiling wit-bindgen-rust-macro v0.24.0
   Compiling heck v0.4.1
   Compiling wit-bindgen-rt v0.24.0
   Compiling quote v1.0.36
   Compiling syn v2.0.58
   Compiling serde_derive v1.0.197
   Compiling indexmap v2.2.6
   Compiling wasmparser v0.202.0
   Compiling wit-parser v0.202.0
   Compiling wasm-metadata v0.202.0
   Compiling wit-bindgen-core v0.24.0
   Compiling wit-component v0.202.0
   Compiling wit-bindgen v0.24.0
   Compiling playground-jco v0.1.0 (/Users/b5/code/playground-jco)
warning: unused import: `__export_world_playground_cabi`
  --> src/bindings.rs:44:16
   |
44 | pub(crate) use __export_world_playground_cabi;
   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused import: `__export_playground_impl as export`
  --> src/bindings.rs:95:16
   |
95 | pub(crate) use __export_playground_impl as export;
   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: function `string_lift` is never used
  --> src/bindings.rs:50:19
   |
50 |     pub unsafe fn string_lift(bytes: Vec<u8>) -> String {
   |                   ^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: function `cabi_dealloc` is never used
  --> src/bindings.rs:57:19
   |
57 |     pub unsafe fn cabi_dealloc(ptr: *mut u8, size: usize, align: usize) {
   |                   ^^^^^^^^^^^^

warning: `playground-jco` (lib) generated 4 warnings (run `cargo fix --lib -p playground-jco` to apply 2 suggestions)
    Finished dev [unoptimized + debuginfo] target(s) in 8.78s
    Creating component target/wasm32-wasi/debug/playground_jco.wasm
error: module does not export required function `scream`
```

* maybe `!!1!` was supposed to be a joke, but in the rust source it reads like some sort of string templating jargon. Maybe stick with `!!!!`?

