### PR TITLE
ref(wasm-pkg): Updates well known file to point to official wasi repo

### DIFF
--- a/wasm-pkg-registry.json
+++ b/wasm-pkg-registry.json
@@ -4,5 +4,5 @@ permalink: .well-known/wasm-pkg/registry.json
 ---
 {
         "ociRegistry": "ghcr.io",
-        "ociNamespacePrefix": "bytecodealliance/wasm-pkg/"
+        "ociNamespacePrefix": "webassembly/"
 }


### PR DESCRIPTION
Since https://github.com/WebAssembly/WASI/issues/606 has been accepted, we should probably make sure the current defaults for bytecodealliance.org actually point at the official wasi packages available [here](https://github.com/orgs/WebAssembly/packages)