### PR TITLE
Plumbers Summit announcement - Sept 2024

### DIFF
--- a/_posts/2024-09-09-our-next-plumbers-summit-event.md
+++ b/_posts/2024-09-09-our-next-plumbers-summit-event.md
@@ -1,0 +1,24 @@
+---
+title: "Our Next Plumbers Summit event - September 26 & 27, 2024"
+author: "Pat Hickey"
+date: "2024-09-09"
+github_name: "pchickey"
+excerpt_separator: <!--end_excerpt-->
+---
+The Bytecode Alliance is pleased to invite you to the next installment in our ongoing Plumbers Summit event series, each designed to bring our members and community contributors together to help set strategic direction and plan efforts for the coming year. Our next Summit will be September 26 and 27, 2024 at the Microsoft Visitor Center in Redmond, Washington. Seating for the in-person session is limited but the event will be live streamed online to support full remote participation.
+<!--end_excerpt-->
+
+
+## Agenda
+Participants will include the maintainers of Wasmtime, jco, and WAMR, as well as the teams working on Component and WASI support in many popular programming languages including Rust, JavaScript, Go, C#, and C++. The event will feature talks and demos on the latest developments in those projects, as well as interactive sessions where both platform developers and users can collaborate on the future of these projects.
+The event will also feature sessions on Component Model packaging, WASI proposals including wasi-nn and wasi-webgpu, and a collaborative session to create and improve documentation and tutorials.
+
+## Event Details
+**Date:** Thursday, September 26 and Friday, September 27 2024  
+**Time:** 9am to 5pm each day  
+**Location:** Microsoft Visitor Center, Building 92, Memphis conference room  
+15010 NE 36th Way, Redmond 98052, WA  
+
+Full registration is now live with tickets available via [Eventbrite](https://www.eventbrite.com/e/bytecode-alliance-plumbers-summit-september-2024-tickets-1008582426187). Please visit the event page to register, selecting either an in-person ticket (for which quantities are limited) or as a remote attendee. We’d like everyone planning on attending to register, allowing us to better coordinate event logistics and also make sure additional information gets out effectively.  Registration will remain open right up until the event (but signing up as early is practical is very much appreciated).
+
+More details on the event agenda are forthcoming. Please let us know if you have any questions about attending, either in person or remotely, and look for further news via our event [stream](https://bytecodealliance.zulipchat.com/#narrow/stream/450847-summit-sept-2024/topic/channel.20events) on the Bytecode Alliance [Zulip server](https://bytecodealliance.zulipchat.com).


### PR DESCRIPTION
Publishing a new News post to the Bytecode Alliance website that announces our September 26 & 27 "Plumbers Summit" event and provides details so folks can register to attend.