### PR TITLE
Added WACE 2025 CFP submission site link

### DIFF
--- a/wace2025.md
+++ b/wace2025.md
@@ -17,7 +17,7 @@ The Bytecode Alliance in partnership with Ghent University - imec  is pleased to
 * Submission deadline: 17 January 2025
 * Acceptance Notification: 28 February 2025
 * Camera-ready deadline: 14 March 2025
-* Submission site: Available soon
+* Submission site: [Online via JEMS](https://jems3.sbc.org.br/events/230)
 
 The workshop Call for Papers is also available in <a href="/assets/WACE_CFP.pdf">PDF form</a>.
 </div>


### PR DESCRIPTION
Updated the web page for our WACE 2025 academic workshop to include a direct link into the JEMS on-line proposal submission system being used for the NOMS 2025 parent conference of which our workshop is a part.