### PR TITLE
Update mission page to replace list of values with the operational principles from the governance repo

### DIFF
--- a/mission.md
+++ b/mission.md
@@ -17,33 +17,69 @@ Our mission is to Provide state-of-the-art foundations to develop runtime enviro
     <div class="container w-container">
         <div class="width-container" markdown="1">
 
-## [Values](#values)
+## Operational Principles
 
-### [Social Values](#social-values)
-1. Collaboration<br>
-   Our alliance facilitates collaborative development.
-2. Inclusiveness<br>
-   Our alliance fosters welcoming, inclusive, and non-discriminatory environments.
-3. Openness<br>
-   What we develop is Free and Open Source, and available for everyone, not just our members. We accept all contributors who are willing and able to collaborate and adhere to our alliance’s values.
+<!-- NOTE: Keep this in sync with the canonical source at https://github.com/bytecodealliance/governance/blob/main/operational-principles.md -->
 
-### [Technical Values](#technical-values)
-1. Thoughtful balance<br>
-   We recognize that many technical principles stand in tension with each other. We will make thoughtful, explicit trade-offs when necessary, but strive for creative solutions that allow those values to all coexist. In particular, we hold the technical principles of Security, Efficiency, Modularity, and Portability as key concerns to balance in all designs and their implementations.
-2. Documentation and Testing<br>
-   We consider documentation and tests a core part of maintainable, sustainable development.
+In pursuing this, the Bytecode Alliance follows a set of operational principles aimed at keeping us aligned on three key aspects: what we want to create, how we want to work together, and how we want to work with others.
 
-### [Process Values](#process-values)
-1. Influence through effort<br>
-   We grant influence and decision-making authority through ongoing efforts towards our alliance’s vision and goals, not through monetary contributions.
-2. Sustainable velocity<br>
-   In all design and implementation decisions, we will take care to balance short-term velocity with stability and maintainability, to sustain a healthy velocity in the long term.
-3. Localized governance wherever possible<br>
-   We localize decision-making processes into individual projects where possible. We lift decisions to a higher governance level only when necessary, such as to mediate deadlocks or facilitate cross-project design and implementation decisions.
-4. Disagree and commit<br>
-   We may re-examine decisions given new evidence or new ideas, and we may document disagreement and trade-offs, but we will not undermine each other’s work.
-5. Lightweight processes<br>
-   We introduce processes as-needed, and make them as lightweight as possible.
+### What we want to create
+
+#### 1. We set rigorous standards for security and quality
+
+We aim to provide state-of-the-art foundations for software development across a wide range of use cases. Adherence to highest standards of security and quality is indispensable for achieving this goal, and is a key consideration in working on our hosted projects.
+
+#### 2. We purposefully build for consistency, stability, security, performance, and interoperability across projects, and standards compliance
+
+Covering the wide range of use cases we target requires adhering to high standards within individual hosted projects on aspects including stability, security, and performance.
+
+Since a key goal for us is a reduction of fragmentation across the ecosystem, we additionally aim to steer hosted projects towards consistency and interoperability, and faithful implementation of applicable standards.
+
+#### 3. We curate
+
+Curation is the process of choosing what to include or exclude in a collection. A curator applies guiding principles to decide what is selected. The Bytecode Alliance deliberately acts as a currator in selecting hosted projects and activities in accordance with our mission and vision under its umbrella.
+
+Not all uses of the technologies we're working on or employ are well-aligned with our mission. When considering feature additions to hosted projects or changes to the scope and goals of SIGs, or the adoption of new hosted projects and SIGs, we carefully evaluate whether the addition actively supports our mission. We might decline the addition if it either is actively harmful to our goals, or not sufficiently related.
+
+Curation does not imply that we prohibit innovation or experimentation. On the contrary, we encourage projects and SIGs that advance the technology while aligning with our overall mission and vision.
+
+### How we want to work together
+
+#### 4. We facilitate collaboration and true multi-stakeholdership
+
+The Bytecode Alliance is a space for true collaboration. No organization or individual must have any kind of privileged position in governance of individual projects or SIGs, or the organization's governance as a whole that's not directly derived from their ongoing contributions. We require hosted projects and SIGs to actively enable full participation in all key project decisions through transparent mechanisms solely based on the value of direct or indirect contributions to the project's goals.
+
+We encourage projects to adopt our [RFC process](https://github.com/bytecodealliance/rfcs/) for major or otherwise impactful decisions.
+
+#### 5. We host open and welcoming communities
+
+Contributors to, collaborators on, and users of our hosted projects and SIGs come from a wide range of backgrounds. We require our hosted projects and SIGs to actively work on creating and remaining spaces open to all.
+
+We reserve in full the right to exclude or limit participation of those who decrease our ability to achieve this goal, and to not be [tolerant of the intolerant](https://en.wikipedia.org/wiki/Paradox_of_tolerance).
+
+#### 6. We actively work against toxicity and exclusion
+
+We require all hosted projects and SIGs to follow and actively enforce our [Code of Conduct](./CODE_OF_CONDUCT.md) without exception.
+
+Additionally, we strongly encourage proactively engaging on early signs of deteriorating relationships or behavior that otherwise points towards a deterioration in community norms and take action before a situation becomes toxic and exclusionary.
+
+### How we want to work with others
+
+#### 7. We collaborate with standards bodies like the W3C and others
+
+The Bytecode Alliance is not a standards body. All aspects of our work that require or would significantly benefit from standardization processes must happen in appropriate standards bodies. The Bytecode Alliance can and will often play a coordinating role to align member interests in these processes, drive design and implementation work, and to facilitate the adoption of standardization outcomes.
+
+#### 8. We are not and don't want to be the only game in town
+
+Realizing our mission will require collaboration of many organizations—not all of which can or will happen within the Bytecode Alliance. Additionally, not all uses of the technologies the Bytecode Alliance is focusing on are aligned with our goals.
+
+Furthermore, healthy standardization processes, crucial to our success, require not just collaboration, but also ongoing competition.
+
+As such, we welcome the existence of other venues of collaboration around these technologies.
+
+#### 9. We empower existing ecosystems instead of disrupting them
+
+We believe that we're better off together with existing ecosystems, enriching them and opening up new possibilities, instead of being a disruptive force.
 
 </div>
 </div>


### PR DESCRIPTION
This has been decided by the board a long time ago, but was never actually done.