### PR TITLE
blog: add release post for Wasmtime 28.0

### DIFF
--- a/_posts/2025-01-03-wasmtime-28.0.md
+++ b/_posts/2025-01-03-wasmtime-28.0.md
@@ -1,0 +1,54 @@
+---
+title: "Wasmtime 28.0: Optimizing at compile-time, Booleans in the Cranelift DSL, and more"
+author: "Eric Gregory"
+date: "2025-01-03"
+github_name: "ericgregory"
+excerpt_separator: <!--end_excerpt-->
+---
+
+[Wasmtime](https://wasmtime.dev/) is a lightweight WebAssembly runtime built for speed, security, and standards-compliance. December's v28.0 release brings enhancements including a new option for optimization at compile-time, a new first-class type for Cranelift's domain-specific language (DSL), and more. 
+
+<!--end_excerpt-->
+
+* The [Instruction Selection Lowering Expressions (ISLE) DSL for Cranelift](https://github.com/bytecodealliance/wasmtime/blob/main/cranelift/isle/docs/language-reference.md) now includes a first-class Boolean type, giving users more tools for expressing parts of the Cranelift compiler backend.
+* The addition of a new single-pass register allocator enables users to choose between optimizing builds for either performance at compile-time or performance at runtime for the generated code.  
+* The public-facing documentation within Wasmtime on memory settings has been reworked and clarified to make usage and configuration clearer.
+
+## What's new in Wasmtime v28.0
+
+Wasmtime v28.0 includes a variety of enhancements and fixes. The release notes are available [here](https://github.com/bytecodealliance/wasmtime/releases/tag/v28.0.0).
+
+### Added
+
+* The ISLE DSL used for Cranelift now has a first-class `bool` type. [#9593](https://github.com/bytecodealliance/wasmtime/pull/9593)
+* Cranelift now supports a new single-pass register allocator designed for compile-time performance (unlike the current default which is optimized for runtime-of-generated-code performance). [#9611](https://github.com/bytecodealliance/wasmtime/pull/9611)
+* The `wasmtime` crate now natively supports the `wasm-wave` crate and its encoding of component value types. [#8872](https://github.com/bytecodealliance/wasmtime/pull/8872)
+* A `Module` can now be created from an already-open file. [#9571](https://github.com/bytecodealliance/wasmtime/pull/9571)
+* A new default-enabled crate feature, `signals-based-traps`, has been added to the `wasmtime` crate. When disabled then runtime signal handling is not required by the host. This is intended to help with future effort to port Wasmtime to more platforms. [#9614](https://github.com/bytecodealliance/wasmtime/pull/9614)
+* Linear memories may now be backed by `malloc` in certain conditions when guard pages are disabled, for example. [#9614](https://github.com/bytecodealliance/wasmtime/pull/9614) [#9634](https://github.com/bytecodealliance/wasmtime/pull/9634)
+* Wasmtime's `async` feature no longer requires `std`. [#9689](https://github.com/bytecodealliance/wasmtime/pull/9689)
+* The buffer and budget capacity of `OutgoingBody` in `wasmtime-wasi-http` are now configurable. [#9670](https://github.com/bytecodealliance/wasmtime/pull/9670)
+
+### Changed
+
+* Wasmtime's external and internal distinction of "static" and "dynamic" memories has been refactored and reworded. All options are preserved but exported under different names with improved documentation about how they all interact with one another (and everything should be easier to understand). [#9545](https://github.com/bytecodealliance/wasmtime/pull/9545)
+* Each `Store<T>` now caches a single fiber stack in async mode to avoid allocating/deallocating if the store is used multiple times. [#9604](https://github.com/bytecodealliance/wasmtime/pull/9604)
+* Linear memories now have a 32MiB guard region at the end instead of a 2GiB guard region by default. [#9606](https://github.com/bytecodealliance/wasmtime/pull/9606)
+* Wasmtime will no longer validate dependencies between WebAssembly features, instead delegating this work to `wasmparser`'s validator. [#9623](https://github.com/bytecodealliance/wasmtime/pull/9623)
+* Cranelift's `isle-in-source-tree` feature has been re-worked as an environment variable. [#9633](https://github.com/bytecodealliance/wasmtime/pull/9633)
+* Wasmtime's minimum supported Rust version is now 1.81. [#9692](https://github.com/bytecodealliance/wasmtime/pull/9692)
+* Synthetic types in DWARF are now more efficiently represented. [#9700](https://github.com/bytecodealliance/wasmtime/pull/9700)
+* Debug builtins on Windows are now exported correctly. [#9706](https://github.com/bytecodealliance/wasmtime/pull/9706)
+* Documentation on `Config` now clarifies that defaults of some options may differ depending on the selected target or compiler depending on features supported. [#9705](https://github.com/bytecodealliance/wasmtime/pull/9705)
+* Wasmtime's error-related types now all unconditionally implement the `Error` trait, even in `#[no_std]` mode. [#9702](https://github.com/bytecodealliance/wasmtime/pull/9702)
+
+### Fixed
+
+* Field type matching for subtyping with wasm GC has been fixed. [#9724](https://github.com/bytecodealliance/wasmtime/pull/9724)
+* Native unwind info generated for s390x has been fixed in the face of tail calls. [#9725](https://github.com/bytecodealliance/wasmtime/pull/9725)
+
+## Get involved
+
+Thanks to [Karl Meakin](https://github.com/Kmeakin), [Chris Fallin](https://github.com/cfallin), [Pat Hickey](https://github.com/pchickey), [Alex Crichton](https://github.com/alexcrichton), [Xinzhao Xu](https://github.com/iawia002), [SingleAccretion](https://github.com/SingleAccretion), [Nick Fitzgerald](https://github.com/fitzgen), and [Ulrich Weigand](https://github.com/uweigand) for their work on this release. 
+
+Want to get involved with Wasmtime? Join the community on our [Zulip chat](https://bytecodealliance.zulipchat.com/) and read the [Wasmtime contributors' guide](https://docs.wasmtime.dev/contributing.html) for more information.


### PR DESCRIPTION
Adds a release post (a bit belatedly, after the holidays) for Wasmtime 28.0.