### PR TITLE
January 2025 website update -- December election outcomes and membership changes

### DIFF
--- a/_data/board.yml
+++ b/_data/board.yml
@@ -9,7 +9,7 @@
 
 - name: Bailey Hayes
   github: ricochet
-  title: TSC Director
+  title: At-Large Director
   office: 
 
 - name: Pat Hickey
@@ -20,11 +20,6 @@
 - name: Tyler McMullen
   github: tyler
   title: Member Director (Fastly)
-  office: 
-
-- name: Till Schneidereit
-  github: tschneidereit
-  title: At-Large Director
   office: 
 
 - name: Ralph Squillace

--- a/_data/members.yml
+++ b/_data/members.yml
@@ -93,7 +93,7 @@
 - name: Liquid Reply
   logo: liquidreply.png
   homepage: https://www.reply.com
-  active: true
+  active: false
 
 - name: Microsoft
   logo: microsoft.svg
@@ -128,7 +128,7 @@
 - name: Redhat
   logo: redhat.png
   homepage: https://www.redhat.com
-  active: true
+  active: false
 
 - name: Shopify
   logo: shopify.svg
@@ -178,7 +178,7 @@
 - name: VMware
   logo: vmware.svg
   homepage: https://www.vmware.com
-  active: true
+  active: false
 
 - name: Shanghai Wudun
   logo: wudun.png

--- a/_data/members.yml
+++ b/_data/members.yml
@@ -28,7 +28,7 @@
 - name: Cisco
   logo: cisco.svg
   homepage: https://cisco.com
-  active: true
+  active: false
 
 - name: Cosmonic
   logo: cosmonic.png

--- a/_data/tsc.yml
+++ b/_data/tsc.yml
@@ -2,17 +2,17 @@
 # Used to generate the gallery of TSC members on the site About page,
 # including photos based on GitHub avatars.  Also links to TSC
 # members' GitHub profiles for further info.
-- name: Nick Fitzgerald
-  github: fitzgen
+- name: Andrew Brown
+  github: abrown
   title: Elected Delegate
-  office: TSC Chair
+  office: 
 
 - name: Bailey Hayes
   github: ricochet
   title: Elected Delegate
   office: 
 
-- name: Till Schneidereit
-  github: tschneidereit
+- name: Oscar Spencer
+  github: ospencer
   title: Elected Delegate
   office: 

--- a/_posts/2025-01-10-election-results.md
+++ b/_posts/2025-01-10-election-results.md
@@ -1,0 +1,33 @@
+---
+title: "Bytecode Alliance Election Results"
+author: "David Bryant"
+date: "2025-01-14"
+github_name: "disquisitioner"
+excerpt_separator: <!--end_excerpt-->
+---
+
+Each December the Bytecode Alliance conducts elections to fill important roles on our governing Board and Technical Steering Committee (TSC). I'm pleased to announce the results of our just-held December 2024 election, in which our Recognized Contributors (RCs) selected three Elected Delegates to the TSC and one At-Large Director to represent them on the Alliance Board.
+
+<!--end_excerpt-->
+
+### TSC Elected Delegates
+
+The Bytecode Alliance Technical Steering Committee acts as the top-level governing body for projects and Special Interest Groups hosted by the Alliance, ensuring they further the Alliance's mission and are conducted in accordance with our values and principles. The TSC also oversees the Bytecode Alliance Recognized Contributor program to encourage and engage individual contributors as participants in Alliance projects and groups.  As defined in its [charter](https://github.com/bytecodealliance/governance/blob/main/TSC/charter.md#composition) the TSC is composed of representatives from each Alliance Core Project and individuals selected by Recogized Contributors.
+
+Our new TSC Elected Delegates (and their GitHub IDs, as we know each other in our RC community) are:
+
+* Andrew Brown (@abrown)
+* Bailey Hayes (@ricochet)
+* Oscar Spencer (@ospencer)
+
+They will each serve a two-year term on the TSC.
+
+### At-Large Director
+
+Our RCs are also represented by two At-Large Directors they select to serve on our Board (as described in our organization [bylaws](https://bytecodealliance.org/assets/bylaws.pdf)), with overlapping two-year terms staggered to start each January. In this most recent election The Recognized Contributors chose Bailey Hayes (@ricochet) as At-Large Director.
+
+### Congratulations!
+
+I look forward to working with each of our electees, and am happy to introduce them here as part of bringing them onboard in their new roles. You'll find our full Board and TSC listed on the [About](https://bytecodealliance.org/about) page of our website. 
+
+Thank you to all our Recognized Contributors for taking part in the election process and in general for their ongoing support of Alliance projects and communities. I'd also like to thank our outgoing leadership for their outstanding work - Nick Fitzgerald (@fitzgen) as TSC Chair and Elected Delegate, and Till Schneidereit (@tschneidereit) as Elected Delegate and At-Large Director.


### PR DESCRIPTION
This PR includes several website changes effective January 1, 2025.  Most of the update relates to the December 2024 Bytecode Alliance election cycle, which included votes by our Recognized Contributors to select three Elected Delegates representing them on our Technical Steering Committee (TSC) as well as an At-Large Director to represent them on the Alliance Board (along with the At-Large Director selected in the December 2023 election).  The TSC and Board sections of our About page have been modified accordingly, along with a short News post announcing the election results.

Also altered is list of active members of the Alliance to reflect some membership changes that took effect on January 1, 2025.