### PR TITLE
Address 404 for CoC

### DIFF
--- a/mission.md
+++ b/mission.md
@@ -59,7 +59,7 @@ We reserve in full the right to exclude or limit participation of those who decr
 
 #### 6. We actively work against toxicity and exclusion
 
-We require all hosted projects and SIGs to follow and actively enforce our [Code of Conduct](./CODE_OF_CONDUCT.md) without exception.
+We require all hosted projects and SIGs to follow and actively enforce our [Code of Conduct](https://github.com/bytecodealliance/rfcs/blob/main/CODE_OF_CONDUCT.md) without exception.
 
 Additionally, we strongly encourage proactively engaging on early signs of deteriorating relationships or behavior that otherwise points towards a deterioration in community norms and take action before a situation becomes toxic and exclusionary.
 


### PR DESCRIPTION
Currently the Code of Conduct link takes you to https://bytecodealliance.org/CODE_OF_CONDUCT.md which 404's

I believe it was meant to link to the file in the rfc's repo.