### PR TITLE
New hosted projects; Updated board

### DIFF
--- a/_data/board.yml
+++ b/_data/board.yml
@@ -37,11 +37,6 @@
   title: Member Director (UCSD)
   office: 
 
-- name: Mingqiu Sun
-  github: mingqiusun
-  title: Member Director (Intel)
-  office: 
-
 # List the Executive Director last (here):
 - name: David Bryant
   github: disquisitioner

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -180,6 +180,15 @@
   status: hosted
   labels: []
 
+- name: tree-sitter-wit
+  description: WebAssembly Interface Types (WIT) grammar for tree-sitter
+  repo: https://github.com/bytecodealliance/tree-sitter-wit
+  site:
+  docs: https://docs.rs/tree-sitter-wit
+  active: true
+  status: hosted
+  labels: [dev-tools]
+
 - name: VSCode-WIT
   description: A Visual Studio Code extension to recognize and highlight the WebAssembly Interface Type (WIT) Interface Definition Language (IDL).
   repo: https://github.com/bytecodealliance/vscode-wit
@@ -414,4 +423,11 @@
   status: hosted
   labels: [protocol]
 
-
+- name: wstd
+  description: An async Rust standard library for Wasm Components and WASI 0.2
+  repo: https://github.com/bytecodealliance/wstd
+  site:
+  docs: https://docs.rs/wstd
+  active: true
+  status: hosted
+  labels: [rust] 


### PR DESCRIPTION
Website update for August 2025, including two changes.  One adds two new approved Hosted Projects to the Projects page, while the other adjusts the list of board members to reflect the current (approved) membership.