### PR TITLE
Update link to WASI Proposals.md

### DIFF
--- a/_posts/2023-07-24-webassembly-the-updated-roadmap-for-developers.md
+++ b/_posts/2023-07-24-webassembly-the-updated-roadmap-for-developers.md
@@ -134,7 +134,7 @@ world proxy {
 }
 ````
 
-The above forms the basis for WASI Preview 2’s standardized interfaces. All the interfaces used by the CLI and HTTP-Proxy worlds will need to have moved to at least Phase 3 by the WASI Sub Group before Preview 2 is officially approved by the WASI Subgroup. Please find more information at [WASI Proposals](https://github.com/WebAssembly/WASI/blob/main/Proposals.md).
+The above forms the basis for WASI Preview 2’s standardized interfaces. All the interfaces used by the CLI and HTTP-Proxy worlds will need to have moved to at least Phase 3 by the WASI Sub Group before Preview 2 is officially approved by the WASI Subgroup. Please find more information at [WASI Proposals](https://github.com/WebAssembly/WASI/blob/main/docs/Proposals.md).
 
 In order to advance WASI Preview 2’s development to stable, we will need to provide documentation, a complete test suite and framework, and two different host implementations:
 


### PR DESCRIPTION
The location of the WASI Proposals.md file has been changed in https://github.com/WebAssembly/WASI/pull/831, this updates all the links in this repository to reflect that change. Thanks!