### PR TITLE
Jan 2026 update

### DIFF
--- a/_data/board.yml
+++ b/_data/board.yml
@@ -24,7 +24,7 @@
 
 - name: Oscar Spencer
   github: ospencer
-  title: TSC Director
+  title: Member Director (F5)
   office: 
 
 - name: Ralph Squillace

--- a/_data/members.yml
+++ b/_data/members.yml
@@ -18,7 +18,7 @@
 - name: Arm
   logo: arm.svg
   homepage: https://arm.com
-  active: true
+  active: false
 
 - name: Candle
   logo: candle.png

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -14,7 +14,7 @@
   repo: https://github.com/bytecodealliance/cargo-component
   site: 
   docs:
-  active: true
+  active: false
   status: hosted
   labels: [rust]
 

--- a/_data/tsc.yml
+++ b/_data/tsc.yml
@@ -2,11 +2,6 @@
 # Used to generate the gallery of TSC members on the site About page,
 # including photos based on GitHub avatars.  Also links to TSC
 # members' GitHub profiles for further info.
-- name: Andrew Brown
-  github: abrown
-  title: Elected Delegate
-  office: TSC Chair
-
 - name: Bailey Hayes
   github: ricochet
   title: Elected Delegate
@@ -20,4 +15,4 @@
 - name: Oscar Spencer
   github: ospencer
   title: Elected Delegate
-  office: TSC Director
+  office:

--- a/wace2025.md
+++ b/wace2025.md
@@ -2,6 +2,7 @@
 layout: default
 permalink: /wace2025
 title: Research Workshops
+published: false
 ---
 
 <section>


### PR DESCRIPTION
Several modest modifications to existing site content, including updates to BA Board and TSC membership arising from the December 2025 election process and maintenance of project and member lists.