### PR TITLE
lowercase asm.js references in retrospective

### DIFF
--- a/_posts/2026-01-22-ten-years-of-webassembly-a-retrospective.md
+++ b/_posts/2026-01-22-ten-years-of-webassembly-a-retrospective.md
@@ -14,7 +14,7 @@ For the ten-year anniversary of the project (well, ten and change), I spoke to m
 
 ## The trusted call stack
 
-In March of 2013, a group of Mozilla engineers including Wagner, Alon Zakai, and Dave Herman released [Asm.js](http://asmjs.org/). Asm.js defined a subset of the existing JavaScript language that implicitly embeds enough static type information to allow a browser's existing JS engine to achieve much better performance once the optimizer knew to look for it. "Super hacky," in Wagner's words.
+In March of 2013, a group of Mozilla engineers including Wagner, Alon Zakai, and Dave Herman released [asm.js](http://asmjs.org/). asm.js defined a subset of the existing JavaScript language that implicitly embeds enough static type information to allow a browser's existing JS engine to achieve much better performance once the optimizer knew to look for it. "Super hacky," in Wagner's words.
 
 Meanwhile, Google was developing [Native Client (NaCl)](https://developer.chrome.com/docs/native-client/) and its successor  [Portable Native Client (PNaCl)](https://chrome.jscn.org/docs/native-client/nacl-and-pnacl/#portable-native-client-pnacl), to sandbox and run native code in Chrome. 
 
@@ -22,21 +22,21 @@ JF Bastien was on the Chrome team at the time, where he helped finalize the Armv
 
 PNaCl placed untrusted code in a separate process from the rest of a web page and its JavaScript&mdash;a reasonable choice for sandboxing, but one that made it difficult for JavaScript to call PNaCl code or vice versa. The connection between PNaCl and the rest of the browser relied on message passing, which required an entirely separate API surface for graphics, audio, and networking. It also forced asynchrony as a programming model, a huge lift to execute successfully. This created obstacles to broader adoption. If PNaCl was going to serve as the basis for a multi-browser approach to native code on the web, what standards body would govern the APIs?
 
-Asm.js took a different approach, which Dan Gohman&mdash;then at Mozilla&mdash;describes as a "trusted call stack," where compiled code and JavaScript could share the same stack. 
+asm.js took a different approach, which Dan Gohman&mdash;then at Mozilla&mdash;describes as a "trusted call stack," where compiled code and JavaScript could share the same stack. 
 
-"That means Asm.js was able to coexist with JavaScript," he says. "You can call into JavaScript, and JavaScript can call into you." This design decision&mdash;later inherited by WebAssembly&mdash;would prove foundational, enabling everything from seamless browser integration to calling functions across isolation boundaries in the Component Model.
+"That means asm.js was able to coexist with JavaScript," he says. "You can call into JavaScript, and JavaScript can call into you." This design decision&mdash;later inherited by WebAssembly&mdash;would prove foundational, enabling everything from seamless browser integration to calling functions across isolation boundaries in the Component Model.
 
 ## "We're going to tell each other's managers that the other one's on board."
 
-By the end of 2013, developers were already compiling C++ games to Asm.js using the [Emscripten](https://emscripten.org/) toolchain, created by Alon Zakai. The Mozilla team was contemplating whether and how to integrate Asm.js into the browser as a solution for running native code. 
+By the end of 2013, developers were already compiling C++ games to asm.js using the [Emscripten](https://emscripten.org/) toolchain, created by Alon Zakai. The Mozilla team was contemplating whether and how to integrate asm.js into the browser as a solution for running native code. 
 
-At Google, the V8 team used Asm.js workloads as one of the benchmarks for a new optimizing compiler called TurboFan. Ben Titzer led the TurboFan effort. Like many of the Wasm co-designers, he was social with engineers at Mozilla, Apple, and Microsoft. Sometimes people moved from one company's browser team to another, and working in the space led naturally to collaboration and more casual socialization. "Drinking and talking about the web," as Bastien says.
+At Google, the V8 team used asm.js workloads as one of the benchmarks for a new optimizing compiler called TurboFan. Ben Titzer led the TurboFan effort. Like many of the Wasm co-designers, he was social with engineers at Mozilla, Apple, and Microsoft. Sometimes people moved from one company's browser team to another, and working in the space led naturally to collaboration and more casual socialization. "Drinking and talking about the web," as Bastien says.
 
-One day, Titzer got into conversation with Wagner about the Mozilla team's plans for Asm.js.
+One day, Titzer got into conversation with Wagner about the Mozilla team's plans for asm.js.
 
 "We're talking to the Google folks," Wagner says, "and they were like, 'We hate this. It's weird, it's gross, it's ad hoc&mdash;why would you even do this? If you want to do this, just do a real bytecode.' And we said: well, we *could*, and this would be the polyfill of it."
 
-"[Asm.js] fundamentally depended on things like array buffers being efficient," Titzer recalls. "I remember having a conversation with Luke about resizable array buffers and whether they could be detached. He was basically trying to convince us that this is a good thing. And he had mentioned off-handedly that maybe Mozilla were thinking that Asm.js wasn't the right way to go. Maybe we should design a bytecode. And my ears perked up at that."
+"[asm.js] fundamentally depended on things like array buffers being efficient," Titzer recalls. "I remember having a conversation with Luke about resizable array buffers and whether they could be detached. He was basically trying to convince us that this is a good thing. And he had mentioned off-handedly that maybe Mozilla were thinking that asm.js wasn't the right way to go. Maybe we should design a bytecode. And my ears perked up at that."
 
 Titzer and Wagner agreed to work together on the project, but now they needed to secure broader buy-in. Together, Wagner says, he and Titzer made a plan: "We're going to tell each other's managers that the other one's on board." 
 
@@ -48,7 +48,7 @@ When someone defines WebAssembly, odds are even that they'll adapt the old joke 
 
 So where, exactly, did the name come from?
 
-"We wanted *asm* in it because of the Asm.js heritage," Wagner says, "and we wanted *web* because all the cool standards of the time had *web*, like WebGL, WebGPU...we wanted to be very clear that this is a a pro-web thing."
+"We wanted *asm* in it because of the asm.js heritage," Wagner says, "and we wanted *web* because all the cool standards of the time had *web*, like WebGL, WebGPU...we wanted to be very clear that this is a a pro-web thing."
 
 The co-designers briefly considered "WebAsm" but (perhaps wisely) passed on that one. So "Asm" was spelled out into "Assembly." WebAssembly.
 
@@ -56,13 +56,13 @@ Bastien recalls internal resistance to the name. "We know it's going to be used 
 
 This writer has certainly used the "neither web nor assembly" line more than once, and so did several of the Wasm co-designers I interviewed, but Wagner gently pushes back on the characterization. 
 
-"Setting aside the Asm.js path dependency, perhaps 'bytecode' or 'intermediate language' would've been a bit more accurate," he says, "but when people say it's not 'web' because it's being used outside the web... well, what's the definition of the web? Is it only things in browsers? The W3C paints a much broader picture of the [open web platform](https://www.w3.org/standards/) that I think covers a lot more of the places where WebAssembly runs today and where we want it to run in the future."
+"Setting aside the asm.js path dependency, perhaps 'bytecode' or 'intermediate language' would've been a bit more accurate," he says, "but when people say it's not 'web' because it's being used outside the web... well, what's the definition of the web? Is it only things in browsers? The W3C paints a much broader picture of the [open web platform](https://www.w3.org/standards/) that I think covers a lot more of the places where WebAssembly runs today and where we want it to run in the future."
 
 ## "Ship as fast as you humanly can before this whole coalition falls apart."
 
 With the Chrome and Firefox teams on the same page, the co-designers turned to the teams at Apple and Microsoft. 
 
-Microsoft's Chakra team, which powered the Edge browser's JavaScript engine, had already implemented Asm.js optimizations&mdash;Wagner had personally relicensed Mozilla source code to make adoption easier. After some "intense Q&A" (in Wagner's words), the Chakra team got on board. At Apple, JavaScriptCore team lead Fil Pizlo (the same Fil of [Fil-C](https://fil-c.org/)) was instrumental in securing buy-in.
+Microsoft's Chakra team, which powered the Edge browser's JavaScript engine, had already implemented asm.js optimizations&mdash;Wagner had personally relicensed Mozilla source code to make adoption easier. After some "intense Q&A" (in Wagner's words), the Chakra team got on board. At Apple, JavaScriptCore team lead Fil Pizlo (the same Fil of [Fil-C](https://fil-c.org/)) was instrumental in securing buy-in.
 
 The four browser engines&mdash;Mozilla's SpiderMonkey, Google's V8, Microsoft's Chakra, and Apple's JavaScriptCore&mdash;would ship WebAssembly support within months of each other. Bastien, who chaired the WebAssembly Community Group during this period, helped set up the organizational structure and operating pace for the W3C standardization process. Before Wagner's first public commit, the team hashed out the basic shape of the project in a shared Google Doc. Wagner then transcribed those agreements into public markdown files. 
 
@@ -76,7 +76,7 @@ For the group working on Wasm, the pressure to ship was intense. "Ship as fast a
 
 ## Treating it as a real thing
 
-Wagner remembers discovering that Facebook had quietly integrated Asm.js into their site to compress JPEGs before upload. "They didn't tell us," he says. "They just did it."
+Wagner remembers discovering that Facebook had quietly integrated asm.js into their site to compress JPEGs before upload. "They didn't tell us," he says. "They just did it."
 
 As Wasm passed from idea to spec to reality, more and more organizations were getting interested. At the second in-person meeting between browser vendors, before the spec was anywhere near complete, a representative from Zynga showed up. Best known at the time for Farmville and other Facebook games, Zynga had built a billion-dollar business on Flash. With Flash on the way to deprecation, they were looking for an alternative.
 
@@ -88,7 +88,7 @@ Gaming had been part of the conversation from the beginning&mdash;early demos fe
 
 ## "Name an API in the world and it's in scope."
 
-Asm.js helped answer the hardest questions for the WebAssembly MVP: What is the security model? What features are in scope? When someone proposed adding coroutines or stack switching, the response was simple, according to Gohman: "That's not in Asm.js. Out of scope. End of story." While the team allowed "a few things that weren’t first-class in Asm.js," in Bastien's words, Asm.js served as a guiding light.
+asm.js helped answer the hardest questions for the WebAssembly MVP: What is the security model? What features are in scope? When someone proposed adding coroutines or stack switching, the response was simple, according to Gohman: "That's not in asm.js. Out of scope. End of story." While the team allowed "a few things that weren’t first-class in asm.js," in Bastien's words, asm.js served as a guiding light.
 
 The next phase of WebAssembly's evolution offered no such scaffold. With the core spec shipped and browsers onboard, attention turned to running WebAssembly outside the browser&mdash;on servers, at the edge, in embedded systems. This meant defining WASI, the [WebAssembly System Interface](https://wasi.dev/), and eventually the [Component Model](https://component-model.bytecodealliance.org/introduction.html). Together, these specifications could allow Wasm binaries to communicate with one another. These "Wasm components" would be able to securely interoperate regardless of the language they were written in.
 
@@ -120,7 +120,7 @@ Bastien agrees. "AI coding agents are are pretty insecure right now, especially 
 
 Meanwhile, some of Wasm's innovations gleaned outside the browser context may return home. Wagner sees the Component Model improving the quality of web developers' experience compiling their language of choice to run in the browser, either mixed into their existing mostly-JS web app, or implementing the whole web app itself.
 
-Today, WebAssembly runs in billions of users' browsers, as well as edge networks, clouds, and embedded systems. The project has achieved standardization and understated ubiquity. It's almost certainly running in one of your most commonly used apps, on one of your everyday devices, right now. What and where could Wasm be in ten years? The fundamentals of the architecture, going all the way back to Asm.js, stuck a toe in the door of a vast possibility space.
+Today, WebAssembly runs in billions of users' browsers, as well as edge networks, clouds, and embedded systems. The project has achieved standardization and understated ubiquity. It's almost certainly running in one of your most commonly used apps, on one of your everyday devices, right now. What and where could Wasm be in ten years? The fundamentals of the architecture, going all the way back to asm.js, stuck a toe in the door of a vast possibility space.
 
 In Gohman's view, WebAssembly represents "one of the few chances that the computing industry has at actually building an execution environment that's truly cloud native. Wasm combines an architecture which differs from what traditional operating systems are designed around, starting with the trusted call stack, and broad relevance, starting with the Web." It will take persistence, but for perhaps the first time in fifty years, he says, there's a chance to innovate at the boundary between kernel and user space. 
 


### PR DESCRIPTION
Updated instances of 'Asm.js' to 'asm.js'. See http://asmjs.org/