### PR TITLE
Add part 1 of Jco blog

### DIFF
--- a/_posts/2026-03-19-five-ways-of-looking-at-jco-part-1.md
+++ b/_posts/2026-03-19-five-ways-of-looking-at-jco-part-1.md
@@ -53,7 +53,7 @@ The Rust crate that makes this possible, [**`js-component-bindgen`**](https://gi
 
 ### WASI P2 shims
 
-Jco ships **WASI P2 shim packages**: JavaScript implementations of [WASI (the WebAssembly System Interface](https://github.com/WebAssembly/WASI), the standard set of I/O APIs for Wasm covering filesystem access, HTTP, clocks, randomness, and more) interfaces that let transpiled components call things like `wasi:http` and `wasi:io` from a browser or Node.js environment.
+Jco ships **WASI P2 shim packages** ([`@bytecodealliance/preview2-shim` on NPM](https://www.npmjs.com/package/@bytecodealliance/preview2-shim)): JavaScript implementations of [WASI (the WebAssembly System Interface](https://github.com/WebAssembly/WASI), the standard set of I/O APIs for Wasm covering filesystem access, HTTP, clocks, randomness, and more) interfaces that let transpiled components call things like `wasi:http` and `wasi:io` from a browser or Node.js environment.
 
 ### WASI P3 shims
 

--- a/_posts/2026-03-19-five-ways-of-looking-at-jco-part-1.md
+++ b/_posts/2026-03-19-five-ways-of-looking-at-jco-part-1.md
@@ -37,7 +37,7 @@ Componentize-js is also in the process of being rewritten to use [`wit-dylib`](h
 
 ### The `jco` CLI
 
-The **`jco` CLI** is the amalgamation of JS WebAssembly ecosystem tools into one user-facing layer. `jco componentize` calls down to componentize-js. But `jco`'s other major capability `jco transpile`operates differently.
+The **`jco` CLI** is the amalgamation of JS WebAssembly ecosystem tools into one user-facing layer. `jco componentize` calls down to `componentize-js`. But `jco`'s other major capability `jco transpile`operates differently.
 
 ### `jco` transpile
 

--- a/_posts/2026-03-19-five-ways-of-looking-at-jco-part-1.md
+++ b/_posts/2026-03-19-five-ways-of-looking-at-jco-part-1.md
@@ -57,7 +57,7 @@ Jco ships **WASI P2 shim packages** ([`@bytecodealliance/preview2-shim` on NPM](
 
 ### WASI P3 shims
 
-P3 shim support is in active development, with full WASI P3 support for Node.js environments imminent in Jco. Browser-side P3 shims are explicitly deferred until the Node.js shims stabilize.
+P3 shim support is in [active development](https://github.com/bytecodealliance/jco/tree/main/packages/preview3-shim), with full WASI P3 support for Node.js environments imminent in Jco. Browser-side P3 shims are explicitly deferred until the Node.js shims stabilize.
 
 ## Looking ahead
 

--- a/_posts/2026-03-19-five-ways-of-looking-at-jco-part-1.md
+++ b/_posts/2026-03-19-five-ways-of-looking-at-jco-part-1.md
@@ -33,7 +33,7 @@ At the base is [**StarlingMonkey**](https://github.com/bytecodealliance/Starling
 
 Componentize-js runs the binary through [**Wizer**](https://github.com/bytecodealliance/wizer), a pre-initialization tool. At build time, Wizer executes the component's startup code (and your JS code at global scope) and snapshots the resulting state. The initialization cost is paid once, at build time, not on every instantiation.
 
-Componentize-js is also in the process of being rewritten to use [`wit-dylib`](https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-dylib) — a relatively new tool Alex Crichton added to `wasm-tools` that significantly simplifies the process of targeting the Component Model from an interpreted language. This rewrite will eliminate a somewhat circular dependency that currently exists in the build (js-component-bindgen, written in Rust, is currently consumed by componentize-js via transpilation, and is also depended on by componentize-js).
+Componentize-js is also in the process of being rewritten to use [`wit-dylib`](https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-dylib) — a relatively new tool Alex Crichton added to `wasm-tools` that significantly simplifies the process of targeting the Component Model from an interpreted language. This rewrite will eliminate a somewhat circular dependency that currently exists in the build ([`js-component-bindgen`](https://crates.io/crates/js-component-bindgen), written in Rust, is currently consumed by componentize-js via transpilation, and is also depended on by componentize-js).
 
 ### The `jco` CLI
 

--- a/_posts/2026-03-19-five-ways-of-looking-at-jco-part-1.md
+++ b/_posts/2026-03-19-five-ways-of-looking-at-jco-part-1.md
@@ -5,7 +5,7 @@ date: "2026-03-19"
 github_name: "ericgregory"
 excerpt_separator: <!--end_excerpt-->
 ---
-Jco is a ["multi-tool for the JS WebAssembly ecosystem."](https://github.com/bytecodealliance/jco) At the 2026 Bytecode Alliance Plumbers Summit, Technical Steering Committee member Bailey Hayes put it another way: Jco is "like five projects in one."
+Jco ([`@bytecodealliance/jco` on NPM](https://www.npmjs.com/package/@bytecodealliance/jco))is a ["multi-tool for the JS WebAssembly ecosystem."](https://github.com/bytecodealliance/jco) At the 2026 Bytecode Alliance Plumbers Summit, Technical Steering Committee member Bailey Hayes put it another way: Jco is "like five projects in one."
 
 It's certainly a project with many facets—five big ones, arguably! Recognizing what those facets are, and how they fit together, is the key to understanding why Jco matters beyond the JavaScript ecosystem. 
 

--- a/_posts/2026-03-19-five-ways-of-looking-at-jco-part-1.md
+++ b/_posts/2026-03-19-five-ways-of-looking-at-jco-part-1.md
@@ -29,7 +29,9 @@ At the base is [**StarlingMonkey**](https://github.com/bytecodealliance/Starling
 
 ### componentize-js
 
-[**componentize-js**](https://github.com/bytecodealliance/ComponentizeJS)  takes your JavaScript source code and bundles it into StarlingMonkey to produce a proper WebAssembly component. Componentize-js runs the binary through [**Wizer**](https://github.com/bytecodealliance/wizer), a pre-initialization tool. At build time, Wizer executes the component's startup code (and your JS code at global scope) and snapshots the resulting state. The initialization cost is paid once, at build time, not on every instantiation.
+[**componentize-js**](https://github.com/bytecodealliance/ComponentizeJS)  takes your JavaScript source code and bundles it into StarlingMonkey to produce a proper WebAssembly component. 
+
+Componentize-js runs the binary through [**Wizer**](https://github.com/bytecodealliance/wizer), a pre-initialization tool. At build time, Wizer executes the component's startup code (and your JS code at global scope) and snapshots the resulting state. The initialization cost is paid once, at build time, not on every instantiation.
 
 Componentize-js is also in the process of being rewritten to use [`wit-dylib`](https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-dylib) — a relatively new tool Alex Crichton added to `wasm-tools` that significantly simplifies the process of targeting the Component Model from an interpreted language. This rewrite will eliminate a somewhat circular dependency that currently exists in the build (js-component-bindgen, written in Rust, is currently consumed by componentize-js via transpilation, and is also depended on by componentize-js).
 

--- a/_posts/2026-03-19-five-ways-of-looking-at-jco-part-1.md
+++ b/_posts/2026-03-19-five-ways-of-looking-at-jco-part-1.md
@@ -41,7 +41,7 @@ The **`jco` CLI** is the amalgamation of JS WebAssembly ecosystem tools into one
 
 ### `jco` transpile
 
-**`jco` transpile** takes any WebAssembly component (written in any language: Rust, Go, Python, C, JavaScript, anything) and converts it into core Wasm modules plus JavaScript glue code that runs in Node.js or any browser with core Wasm support. No native Component Model support required. 
+**`jco` transpile** ([`@bytecodealliance/jco-transpile` on NPM](https://www.npmjs.com/package/@bytecodealliance/jco-transpile) or via the `jco transpile` CLI) takes any WebAssembly component (written in any language: Rust, Go, Python, C, JavaScript, anything) and converts it into core Wasm modules plus JavaScript glue code that runs in Node.js or any browser with core Wasm support. No native Component Model support required. 
 
 Under the hood, this involves "unbundling" the component—decomposing it into its constituent core Wasm modules with the imports and exports they need, then generating the glue code that implements Component Model semantics on top of those.
 

--- a/_posts/2026-03-19-five-ways-of-looking-at-jco-part-1.md
+++ b/_posts/2026-03-19-five-ways-of-looking-at-jco-part-1.md
@@ -49,7 +49,7 @@ Under the hood, this involves "unbundling" the component—decomposing it into i
 
 ### js-component-bindgen
 
-The Rust crate that makes this possible, [**`js-component-bindgen`**](https://github.com/bytecodealliance/jco/tree/main/crates/js-component-bindgen), handles the heavy lifting of generating correct "lifting and lowering" glue code for every Component Model type and intrinsic based on the WIT contract that you've specified for your component—that is to say, the translation layer that converts between Wasm's binary value representation (a string is a memory pointer plus a byte length) and idiomatic JavaScript types that your code works with.
+The Rust crate that makes this possible, [**`js-component-bindgen`**](https://github.com/bytecodealliance/jco/tree/main/crates/js-component-bindgen) ([`js-component-bindgen` on crates.io](https://crates.io/crates/js-component-bindgen)), handles the heavy lifting of generating correct "lifting and lowering" glue code for every Component Model type and intrinsic based on the WIT contract that you've specified for your component—that is to say, the translation layer that converts between Wasm's binary value representation (a string is a memory pointer plus a byte length) and idiomatic JavaScript types that your code works with.
 
 ### WASI P2 shims
 

--- a/_posts/2026-03-19-five-ways-of-looking-at-jco-part-1.md
+++ b/_posts/2026-03-19-five-ways-of-looking-at-jco-part-1.md
@@ -1,0 +1,62 @@
+---
+title: "Five ways of looking at Jco, Part 1"
+author: "Eric Gregory"
+date: "2026-03-19"
+github_name: "ericgregory"
+excerpt_separator: <!--end_excerpt-->
+---
+Jco is a ["multi-tool for the JS WebAssembly ecosystem."](https://github.com/bytecodealliance/jco) At the 2026 Bytecode Alliance Plumbers Summit, Technical Steering Committee member Bailey Hayes put it another way: Jco is "like five projects in one."
+
+It's certainly a project with many facets—five big ones, arguably! Recognizing what those facets are, and how they fit together, is the key to understanding why Jco matters beyond the JavaScript ecosystem. 
+
+In this blog series, we'll draw on [Victor Adossi's Plumbers Summit presentation](https://github.com/bytecodealliance/meetings/blob/main/plumbers-summit/summit-feb26/slides/jco-and-browsers.pdf) to take an in-depth look at Jco from five different perspectives, in order to better grasp how you can use (and contribute to!) Jco today. There’s a lot to unpack here, so in this first post, we’ll try to get to grips with Jco as a layered architecture that brings together many pieces of the Wasm and JS ecosystem.
+
+<!--end_excerpt-->
+
+## 1. Wasm and JS ecosystem
+
+To understand Jco, it helps to understand its layers.
+
+![jco-architecture.svg](../images/jco-architecture.svg)
+
+## Building JS components
+
+Here are the projects that are involved when using JavaScript to build new WebAssembly components:
+
+### StarlingMonkey
+
+At the base is [**StarlingMonkey**](https://github.com/bytecodealliance/StarlingMonkey): a JavaScript runtime built on SpiderMonkey (the same engine that powers Firefox) that compiles to WebAssembly. StarlingMonkey adds the Component Model wiring that SpiderMonkey itself doesn't include, handling the communication that occurs when a JS component calls an import or exposes an export.
+
+### componentize-js
+
+[**componentize-js**](https://github.com/bytecodealliance/ComponentizeJS)  takes your JavaScript source code and bundles it into StarlingMonkey to produce a proper WebAssembly component. Componentize-js runs the binary through [**Wizer**](https://github.com/bytecodealliance/wizer), a pre-initialization tool. At build time, Wizer executes the component's startup code (and your JS code at global scope) and snapshots the resulting state. The initialization cost is paid once, at build time, not on every instantiation.
+
+Componentize-js is also in the process of being rewritten to use [`wit-dylib`](https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-dylib) — a relatively new tool Alex Crichton added to `wasm-tools` that significantly simplifies the process of targeting the Component Model from an interpreted language. This rewrite will eliminate a somewhat circular dependency that currently exists in the build (js-component-bindgen, written in Rust, is currently consumed by componentize-js via transpilation, and is also depended on by componentize-js).
+
+### The `jco` CLI
+
+The **`jco` CLI** is the amalgamation of JS WebAssembly ecosystem tools into one user-facing layer. `jco componentize` calls down to componentize-js. But `jco`'s other major capability `jco transpile`operates differently.
+
+### `jco` transpile
+
+**`jco` transpile** takes any WebAssembly component (written in any language: Rust, Go, Python, C, JavaScript, anything) and converts it into core Wasm modules plus JavaScript glue code that runs in Node.js or any browser with core Wasm support. No native Component Model support required. 
+
+Under the hood, this involves "unbundling" the component—decomposing it into its constituent core Wasm modules with the imports and exports they need, then generating the glue code that implements Component Model semantics on top of those.
+
+![jco-transpile.svg](../images/jco-transpile.svg)
+
+### js-component-bindgen
+
+The Rust crate that makes this possible, [**`js-component-bindgen`**](https://github.com/bytecodealliance/jco/tree/main/crates/js-component-bindgen), handles the heavy lifting of generating correct "lifting and lowering" glue code for every Component Model type and intrinsic based on the WIT contract that you've specified for your component—that is to say, the translation layer that converts between Wasm's binary value representation (a string is a memory pointer plus a byte length) and idiomatic JavaScript types that your code works with.
+
+### WASI P2 shims
+
+Jco ships **WASI P2 shim packages**: JavaScript implementations of [WASI (the WebAssembly System Interface](https://github.com/WebAssembly/WASI), the standard set of I/O APIs for Wasm covering filesystem access, HTTP, clocks, randomness, and more) interfaces that let transpiled components call things like `wasi:http` and `wasi:io` from a browser or Node.js environment.
+
+### WASI P3 shims
+
+P3 shim support is in active development, with full WASI P3 support for Node.js environments imminent in Jco. Browser-side P3 shims are explicitly deferred until the Node.js shims stabilize.
+
+## Looking ahead
+
+In the next blog, we’ll take a look at four more ways of thinking about Jco, and break down how you can get involved. In the meantime, if you have questions or want to jump in right away, make sure to join the community on the [Bytecode Alliance Zulip has a `jco` channel](https://bytecodealliance.zulipchat.com/#narrow/stream/409526-jco).

--- a/_posts/2026-03-19-five-ways-of-looking-at-jco-part-1.md
+++ b/_posts/2026-03-19-five-ways-of-looking-at-jco-part-1.md
@@ -59,4 +59,4 @@ P3 shim support is in active development, with full WASI P3 support for Node.js 
 
 ## Looking ahead
 
-In the next blog, we’ll take a look at four more ways of thinking about Jco, and break down how you can get involved. In the meantime, if you have questions or want to jump in right away, make sure to join the community on the [Bytecode Alliance Zulip has a `jco` channel](https://bytecodealliance.zulipchat.com/#narrow/stream/409526-jco).
+In the next blog, we’ll take a look at four more ways of thinking about Jco, and break down how you can get involved. In the meantime, if you have questions or want to jump in right away, make sure to join the community on the [Bytecode Alliance Zulip `jco` channel](https://bytecodealliance.zulipchat.com/#narrow/stream/409526-jco).

--- a/images/jco-architecture.svg
+++ b/images/jco-architecture.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 325" style="font-family: system-ui, sans-serif; max-width: 100%; display: block; margin: 1.5em 0;">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 362" style="font-family: system-ui, sans-serif; max-width: 100%; display: block; margin: 1.5em 0;">
   <defs>
     <marker id="arr" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
       <polygon points="0 0, 8 3, 0 6" fill="#4a6090"/>
@@ -51,12 +51,12 @@
   <line x1="572" y1="257" x2="572" y2="234" stroke="#4a6090" stroke-width="1.5" marker-end="url(#arr)"/>
 
   <!-- Dep row 2 -->
-  <rect x="40" y="259" width="295" height="57" rx="5" fill="#eef2fb" stroke="#4a6090" stroke-width="1.5"/>
+  <rect x="40" y="259" width="295" height="68" rx="5" fill="#eef2fb" stroke="#4a6090" stroke-width="1.5"/>
   <text x="187" y="280" text-anchor="middle" font-size="13" font-weight="600" fill="#1a2e5a">StarlingMonkey</text>
   <text x="187" y="297" text-anchor="middle" font-size="10" fill="#4a5070">SpiderMonkey compiled to WebAssembly;</text>
   <text x="187" y="311" text-anchor="middle" font-size="10" fill="#4a5070">adds Component Model wiring</text>
 
-  <rect x="425" y="259" width="295" height="57" rx="5" fill="#eef2fb" stroke="#4a6090" stroke-width="1.5"/>
+  <rect x="425" y="259" width="295" height="68" rx="5" fill="#eef2fb" stroke="#4a6090" stroke-width="1.5"/>
   <text x="572" y="280" text-anchor="middle" font-size="13" font-weight="600" fill="#1a2e5a">WASI shim packages</text>
   <text x="572" y="297" text-anchor="middle" font-size="10" fill="#4a5070">JS implementations of WASI P2 + P3</text>
   <text x="572" y="311" text-anchor="middle" font-size="10" fill="#4a5070">(filesystem, HTTP, clocks, …)</text>

--- a/images/jco-architecture.svg
+++ b/images/jco-architecture.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 325" style="font-family: system-ui, sans-serif; max-width: 100%; display: block; margin: 1.5em 0;">
+  <defs>
+    <marker id="arr" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#4a6090"/>
+    </marker>
+  </defs>
+
+  <!-- Outputs (top, green) -->
+  <rect x="40" y="10" width="295" height="45" rx="5" fill="#e8f4e8" stroke="#3a7a3a" stroke-width="1.5"/>
+  <text x="187" y="31" text-anchor="middle" font-size="12" font-weight="600" fill="#1a3a1a">Wasm component</text>
+  <text x="187" y="47" text-anchor="middle" font-size="10" fill="#4a5a4a">runs on any Component Model host</text>
+
+  <rect x="425" y="10" width="295" height="45" rx="5" fill="#e8f4e8" stroke="#3a7a3a" stroke-width="1.5"/>
+  <text x="572" y="31" text-anchor="middle" font-size="12" font-weight="600" fill="#1a3a1a">ES Module</text>
+  <text x="572" y="47" text-anchor="middle" font-size="10" fill="#4a5a4a">runs in any JS host supporting core Wasm</text>
+
+  <!-- Arrows: jco CLI → outputs (upward, arrowhead at outputs) -->
+  <line x1="187" y1="80" x2="187" y2="57" stroke="#4a6090" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="572" y1="80" x2="572" y2="57" stroke="#4a6090" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- jco CLI (middle, split with divider) -->
+  <rect x="40" y="82" width="680" height="65" rx="5" fill="#d0dbf5" stroke="#4a6090" stroke-width="1.5"/>
+  <!-- "jco CLI" parent label centered at top -->
+  <text x="380" y="97" text-anchor="middle" font-size="11" font-weight="600" fill="#1a2e5a" opacity="0.55">jco CLI</text>
+  <!-- Vertical dashed divider splitting guest / host -->
+  <line x1="380" y1="88" x2="380" y2="142" stroke="#4a6090" stroke-width="1" stroke-dasharray="4,3"/>
+  <!-- Left: jco componentize + Guest workflows label -->
+  <text x="210" y="114" text-anchor="middle" font-size="13" font-weight="700" fill="#1a2e5a">jco componentize</text>
+  <text x="210" y="131" text-anchor="middle" font-size="10" font-style="italic" fill="#4a5070">Guest workflows</text>
+  <!-- Right: jco transpile + Host workflows label -->
+  <text x="550" y="114" text-anchor="middle" font-size="13" font-weight="700" fill="#1a2e5a">jco transpile</text>
+  <text x="550" y="131" text-anchor="middle" font-size="10" font-style="italic" fill="#4a5070">Host workflows</text>
+
+  <!-- Arrows: dep row 1 → jco CLI (upward, arrowhead at jco) -->
+  <line x1="187" y1="165" x2="187" y2="149" stroke="#4a6090" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="572" y1="165" x2="572" y2="149" stroke="#4a6090" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Dep row 1 -->
+  <rect x="40" y="167" width="295" height="65" rx="5" fill="#eef2fb" stroke="#4a6090" stroke-width="1.5"/>
+  <text x="187" y="189" text-anchor="middle" font-size="13" font-weight="600" fill="#1a2e5a">componentize-js</text>
+  <text x="187" y="206" text-anchor="middle" font-size="10" fill="#4a5070">bundles JS source into StarlingMonkey,</text>
+  <text x="187" y="220" text-anchor="middle" font-size="10" fill="#4a5070">pre-initializes with Wizer</text>
+
+  <rect x="425" y="167" width="295" height="65" rx="5" fill="#eef2fb" stroke="#4a6090" stroke-width="1.5"/>
+  <text x="572" y="189" text-anchor="middle" font-size="13" font-weight="600" fill="#1a2e5a">js-component-bindgen</text>
+  <text x="572" y="206" text-anchor="middle" font-size="10" fill="#4a5070">generates lifting &amp; lowering code;</text>
+  <text x="572" y="220" text-anchor="middle" font-size="10" fill="#4a5070">outputs core Wasm + JS glue</text>
+
+  <!-- Arrows: dep row 2 → dep row 1 (upward, arrowhead at dep row 1) -->
+  <line x1="187" y1="257" x2="187" y2="234" stroke="#4a6090" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="572" y1="257" x2="572" y2="234" stroke="#4a6090" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Dep row 2 -->
+  <rect x="40" y="259" width="295" height="57" rx="5" fill="#eef2fb" stroke="#4a6090" stroke-width="1.5"/>
+  <text x="187" y="280" text-anchor="middle" font-size="13" font-weight="600" fill="#1a2e5a">StarlingMonkey</text>
+  <text x="187" y="297" text-anchor="middle" font-size="10" fill="#4a5070">SpiderMonkey compiled to WebAssembly;</text>
+  <text x="187" y="311" text-anchor="middle" font-size="10" fill="#4a5070">adds Component Model wiring</text>
+
+  <rect x="425" y="259" width="295" height="57" rx="5" fill="#eef2fb" stroke="#4a6090" stroke-width="1.5"/>
+  <text x="572" y="280" text-anchor="middle" font-size="13" font-weight="600" fill="#1a2e5a">WASI shim packages</text>
+  <text x="572" y="297" text-anchor="middle" font-size="10" fill="#4a5070">JS implementations of WASI P2 + P3</text>
+  <text x="572" y="311" text-anchor="middle" font-size="10" fill="#4a5070">(filesystem, HTTP, clocks, …)</text>
+</svg>

--- a/images/jco-transpile.svg
+++ b/images/jco-transpile.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 395" style="font-family: system-ui, sans-serif; max-width: 100%; display: block; margin: 1.5em 0;">
+  <defs>
+    <marker id="arr" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#4a6090"/>
+    </marker>
+  </defs>
+
+  <!-- Input: Wasm Component -->
+  <rect x="125" y="15" width="270" height="60" rx="5" fill="#eef2fb" stroke="#4a6090" stroke-width="1.5"/>
+  <text x="260" y="40" text-anchor="middle" font-size="13" font-weight="600" fill="#1a2e5a">Wasm Component</text>
+  <text x="260" y="57" text-anchor="middle" font-size="10" fill="#4a5070">JavaScript / Rust / Go / Python / etc.</text>
+
+  <!-- Arrow 1: Wasm Component → jco transpile -->
+  <line x1="260" y1="75" x2="260" y2="99" stroke="#4a6090" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- jco transpile container -->
+  <rect x="30" y="101" width="460" height="125" rx="5" fill="#d0dbf5" stroke="#4a6090" stroke-width="1.5"/>
+  <text x="260" y="119" text-anchor="middle" font-size="13" font-weight="700" fill="#1a2e5a">jco transpile</text>
+
+  <!-- Left sub-box: wasm-tools.js -->
+  <rect x="45" y="126" width="195" height="92" rx="4" fill="#eef2fb" stroke="#4a6090" stroke-width="1"/>
+  <text x="143" y="146" text-anchor="middle" font-size="12" font-weight="600" fill="#1a2e5a">wasm-tools.js</text>
+  <text x="143" y="162" text-anchor="middle" font-size="10" fill="#4a5070">(subproject that unpacks)</text>
+  <text x="59" y="180" font-size="10" fill="#4a5070">• wasi shim packages</text>
+  <text x="59" y="196" font-size="10" fill="#4a5070">• unpack core modules</text>
+
+  <!-- Right sub-box: js-component-bindgen -->
+  <rect x="258" y="126" width="215" height="92" rx="4" fill="#eef2fb" stroke="#4a6090" stroke-width="1"/>
+  <text x="366" y="153" text-anchor="middle" font-size="12" font-weight="600" fill="#1a2e5a">js-component-bindgen</text>
+  <text x="366" y="171" text-anchor="middle" font-size="10" fill="#4a5070">generates lifting &amp;</text>
+  <text x="366" y="186" text-anchor="middle" font-size="10" fill="#4a5070">lowering code</text>
+
+  <!-- Arrow 2: jco transpile → ES Module -->
+  <line x1="260" y1="226" x2="260" y2="249" stroke="#4a6090" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Output: ES Module -->
+  <rect x="125" y="251" width="270" height="95" rx="5" fill="#e8f4e8" stroke="#3a7a3a" stroke-width="1.5"/>
+  <text x="260" y="271" text-anchor="middle" font-size="13" font-weight="700" fill="#1a3a1a">ES Module</text>
+  <text x="145" y="290" font-size="11" fill="#1a3a1a">• component.js</text>
+  <text x="145" y="308" font-size="11" fill="#1a3a1a">• component.coreX.wasm</text>
+  <text x="145" y="326" font-size="11" fill="#1a3a1a">• interfaces/</text>
+
+  <!-- Arrow 3: ES Module → usage -->
+  <line x1="260" y1="346" x2="260" y2="361" stroke="#4a6090" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Usage example -->
+  <rect x="85" y="363" width="350" height="24" rx="4" fill="#f5f5f5" stroke="#bbb" stroke-width="1"/>
+  <text x="260" y="379" text-anchor="middle" font-size="11" font-family="ui-monospace, monospace" fill="#333">import('./transpiled/component.js')</text>
+</svg>

--- a/images/jco-transpile.svg
+++ b/images/jco-transpile.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 395" style="font-family: system-ui, sans-serif; max-width: 100%; display: block; margin: 1.5em 0;">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 412" style="font-family: system-ui, sans-serif; max-width: 100%; display: block; margin: 1.5em 0;">
   <defs>
     <marker id="arr" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
       <polygon points="0 0, 8 3, 0 6" fill="#4a6090"/>


### PR DESCRIPTION
Adds Part 1 of blog exploring Jco from five different angles:

1) Wasm and JS ecosystem
2) The host as guest
3) Jco as reference implementation for the Component Model
4) The browser story
5) Jco as developer tooling

Victor suggested breaking it down into multiple blogs; the rest is drafted and I would expect it to follow shortly after.